### PR TITLE
Redirect unknown routes to home

### DIFF
--- a/analytics/events.js
+++ b/analytics/events.js
@@ -18,6 +18,7 @@ export const EVENTS = {
     BOOK_NOW: 'book_now_click',
     CONTACT_CLICK: 'contact_click',
     FAQ_INTERACTION: 'faq_interaction',
+    NOT_FOUND_REDIRECT: 'not_found_redirect',
 }
 
 export function trackPageView (props) {
@@ -86,4 +87,8 @@ export function trackContactClick (props) {
 
 export function trackFaqInteraction (props) {
     captureEvent(EVENTS.FAQ_INTERACTION, props)
+}
+
+export function trackNotFoundRedirect (props) {
+    captureEvent(EVENTS.NOT_FOUND_REDIRECT, props)
 }

--- a/analytics/posthog.config.js
+++ b/analytics/posthog.config.js
@@ -19,8 +19,9 @@ export function initPostHog () {
     try {
         posthog.init(POSTHOG_KEY, {
             api_host: POSTHOG_HOST,
-            capture_pageview: false,
-            autocapture: false,
+            capture_pageview: true,
+            autocapture: true,
+            disable_session_recording: false,
             session_recording: {
                 maskAllInputs: false,
             },

--- a/src/app/[...notFound]/page.tsx
+++ b/src/app/[...notFound]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect } from 'react'
 import { useRouter } from 'next/navigation'
-import { trackNotFoundRedirect } from '@/analytics/events'
+import { trackNotFoundRedirect } from '../../../analytics/events'
 
 export default function NotFoundRedirectPage () {
     const router = useRouter()

--- a/src/app/[...notFound]/page.tsx
+++ b/src/app/[...notFound]/page.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { trackNotFoundRedirect } from '@/analytics/events'
+
+export default function NotFoundRedirectPage () {
+    const router = useRouter()
+
+    useEffect(() => {
+        trackNotFoundRedirect({ path: window.location.pathname })
+        router.replace('/')
+    }, [router])
+
+    return null
+}

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -1,8 +1,37 @@
 import { render, screen } from '@testing-library/react'
 import Page from '../app/page'
+import { CalProvider } from '@/components/CalProvider'
+import { ThemeProvider } from 'next-themes'
+
+beforeAll(() => {
+    class MockIntersectionObserver {
+        observe () {}
+        unobserve () {}
+        disconnect () {}
+    }
+    // @ts-ignore
+    window.IntersectionObserver = MockIntersectionObserver
+    // @ts-ignore
+    window.matchMedia = window.matchMedia || function () {
+        return {
+            matches: false,
+            addListener () {},
+            removeListener () {},
+        }
+    }
+})
 
 describe('Home', () => {
     it('renders a heading', () => {
-        render(<Page />)
+        render(
+            <ThemeProvider attribute="class">
+                <CalProvider>
+                    <Page />
+                </CalProvider>
+            </ThemeProvider>
+        )
+        expect(
+            screen.getByRole('heading', { name: /The Bay Area Tutor/i })
+        ).toBeInTheDocument()
     })
 })

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -3,6 +3,10 @@ import Page from '../app/page'
 import { CalProvider } from '@/components/CalProvider'
 import { ThemeProvider } from 'next-themes'
 
+jest.mock('lucide-react', () => new Proxy({}, {
+    get: () => () => null,
+}))
+
 beforeAll(() => {
     class MockIntersectionObserver {
         observe () {}


### PR DESCRIPTION
## Summary
- redirect unknown paths to home page and log PostHog event
- enable comprehensive PostHog capturing and fix home page test environment

## Testing
- `npx --yes jest --runInBand`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1b379a92c8325a943b1b4881fe5d6