### PR TITLE
feat: add granular PostHog tracking

### DIFF
--- a/analytics/tracking.hooks.js
+++ b/analytics/tracking.hooks.js
@@ -16,7 +16,7 @@ import {
     trackContactClick,
     trackFaqInteraction,
 } from './events.js'
-import { identifyUser, setupErrorTracking, timeOnPage, resetTimer, trackPerformance } from './utils.js'
+import { identifyUser, setupErrorTracking, timeOnPage, resetTimer, trackPerformance, captureEvent } from './utils.js'
 
 export function useAnalytics (userId) {
     useEffect(() => {
@@ -45,6 +45,8 @@ export function useAnalytics (userId) {
             const action = target.dataset.action
             if (action === 'schedule_now') {
                 trackScheduleNow({ page_location, timestamp })
+                const custom = target.dataset.phEvent
+                if (custom) captureEvent(custom, { page_location, timestamp, label: target.dataset.phLabel || target.textContent })
                 return
             }
 
@@ -55,6 +57,14 @@ export function useAnalytics (userId) {
                     group: target.dataset.group,
                     timestamp,
                 })
+                const custom = target.dataset.phEvent
+                if (custom) captureEvent(custom, { page_location, timestamp, label: target.dataset.phLabel || target.textContent })
+                return
+            }
+
+            const customEvent = target.dataset.phEvent
+            if (customEvent) {
+                captureEvent(customEvent, { page_location, timestamp, label: target.dataset.phLabel || target.textContent || target.href })
                 return
             }
 

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -174,6 +174,7 @@ export default function About () {
                             <button
                                 onClick={() => open()}
                                 className="schedule-trigger academic-button px-8 py-3 text-lg font-semibold rounded-lg"
+                                data-ph-event="about_schedule_free_consultation_click"
                             >
                                 Schedule Your Free Consultation
                             </button>

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -108,6 +108,7 @@ export default function Contact () {
                             <button
                                 onClick={() => open()}
                                 className="schedule-trigger academic-button px-6 py-4 text-lg font-semibold rounded-lg flex items-center justify-center space-x-2 mx-auto"
+                                data-ph-event="contact_schedule_now_click"
                             >
                                 <Calendar className="w-5 h-5" />
                                 <span>Schedule Now</span>

--- a/src/components/FAQ.tsx
+++ b/src/components/FAQ.tsx
@@ -3,6 +3,8 @@
 import { useState } from 'react'
 import { ChevronDown, ChevronUp, HelpCircle } from 'lucide-react'
 import { siteContent } from '@/data/siteContent'
+import { createSlug } from '@/utils/formatters'
+import { captureEvent } from '../../analytics/utils'
 
 // FAQ SVG Icon
 const FAQIcon = () => (
@@ -21,7 +23,14 @@ export default function FAQ () {
     const [ openItem, setOpenItem ] = useState<number | null>(null)
 
     const toggleItem = (index: number) => {
-        setOpenItem(openItem === index ? null : index)
+        const isOpening = openItem !== index
+        setOpenItem(isOpening ? index : null)
+        const faq = faqs[index]
+        captureEvent(`faq_toggle_${createSlug(faq.question)}` , {
+            faq_id: createSlug(faq.question),
+            question: faq.question,
+            state: isOpening ? 'open' : 'close',
+        })
     }
 
     const faqs: FAQItem[] = siteContent.faq.items.map(item => ({
@@ -88,6 +97,7 @@ export default function FAQ () {
                                     if (element) element.scrollIntoView({ behavior: 'smooth' })
                                 }}
                                 className="academic-button px-6 py-3 font-semibold rounded-lg"
+                                data-ph-event="faq_ask_question_click"
                             >
                                 Ask Your Question
                             </button>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -57,6 +57,7 @@ export default function Footer () {
                                 <button
                                     onClick={() => scrollToSection('services')}
                                     className="text-academic-medium-blue dark:text-academic-off-white hover:text-academic-gold transition-colors text-sm"
+                                    data-ph-event="footer_test_preparation_click"
                                 >
                                     Test Preparation
                                 </button>
@@ -65,6 +66,7 @@ export default function Footer () {
                                 <button
                                     onClick={() => scrollToSection('services')}
                                     className="text-academic-medium-blue dark:text-academic-off-white hover:text-academic-gold transition-colors text-sm"
+                                    data-ph-event="footer_academic_support_click"
                                 >
                                     Academic Support
                                 </button>
@@ -73,6 +75,7 @@ export default function Footer () {
                                 <button
                                     onClick={() => scrollToSection('services')}
                                     className="text-academic-medium-blue dark:text-academic-off-white hover:text-academic-gold transition-colors text-sm"
+                                    data-ph-event="footer_personalized_learning_click"
                                 >
                                     Personalized Learning
                                 </button>
@@ -81,6 +84,7 @@ export default function Footer () {
                                 <button
                                     onClick={() => scrollToSection('contact')}
                                     className="text-academic-medium-blue dark:text-academic-off-white hover:text-academic-gold transition-colors text-sm"
+                                    data-ph-event="footer_free_consultation_click"
                                 >
                                     Free Consultation
                                 </button>
@@ -115,6 +119,7 @@ export default function Footer () {
                         <button
                             onClick={scrollToTop}
                             className="flex items-center space-x-2 text-academic-medium-blue dark:text-academic-off-white hover:text-academic-gold transition-colors text-sm"
+                            data-ph-event="footer_back_to_top_click"
                         >
                             <span>Back to Top</span>
                             <ArrowUp className="w-4 h-4" />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -74,18 +74,21 @@ export default function Header () {
                             <button
                                 onClick={() => scrollToSection('services')}
                                 className="text-academic-navy dark:text-white hover:text-academic-gold transition-colors font-medium"
+                                data-ph-event="nav_services_click"
                             >
                                 Services
                             </button>
                             <button
                                 onClick={() => scrollToSection('about')}
                                 className="text-academic-navy dark:text-white hover:text-academic-gold transition-colors font-medium"
+                                data-ph-event="nav_about_click"
                             >
                                 About
                             </button>
                             <button
                                 onClick={() => scrollToSection('faq')}
                                 className="text-academic-navy dark:text-white hover:text-academic-gold transition-colors font-medium"
+                                data-ph-event="nav_faq_click"
                             >
                                 FAQ
                             </button>
@@ -93,6 +96,7 @@ export default function Header () {
                                 onClick={() => handleScheduleClick()}
                                 data-action="schedule_now"
                                 className="schedule-trigger academic-button px-6 py-2 text-sm font-semibold rounded-md flex items-center space-x-2"
+                                data-ph-event="nav_schedule_now_click"
                             >
                                 <Calendar className="w-4 h-4" />
                                 <span>Schedule Now</span>
@@ -104,6 +108,7 @@ export default function Header () {
                         <button
                             onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
                             className="lg:hidden text-academic-navy dark:text-white p-2"
+                            data-ph-event="nav_mobile_menu_toggle"
                         >
                             {isMobileMenuOpen ? <X className="w-6 h-6" /> : <Menu className="w-6 h-6" />}
                         </button>
@@ -115,18 +120,21 @@ export default function Header () {
                             <button
                                 onClick={() => scrollToSection('services')}
                                 className="block w-full text-left text-academic-navy dark:text-white hover:text-academic-gold transition-colors font-medium py-2"
+                                data-ph-event="mobile_nav_services_click"
                             >
                                 Services
                             </button>
                             <button
                                 onClick={() => scrollToSection('about')}
                                 className="block w-full text-left text-academic-navy dark:text-white hover:text-academic-gold transition-colors font-medium py-2"
+                                data-ph-event="mobile_nav_about_click"
                             >
                                 About
                             </button>
                             <button
                                 onClick={() => scrollToSection('faq')}
                                 className="block w-full text-left text-academic-navy dark:text-white hover:text-academic-gold transition-colors font-medium py-2"
+                                data-ph-event="mobile_nav_faq_click"
                             >
                                 FAQ
                             </button>
@@ -134,6 +142,7 @@ export default function Header () {
                                 onClick={handleScheduleClick}
                                 data-action="schedule_now"
                                 className="schedule-trigger academic-button w-full px-4 py-2 text-sm font-semibold rounded-md flex items-center justify-center space-x-2"
+                                data-ph-event="mobile_nav_schedule_now_click"
                             >
                                 <Calendar className="w-4 h-4" />
                                 <span>Schedule Now</span>
@@ -151,6 +160,7 @@ export default function Header () {
                 <button
                     onClick={() => handleScheduleClick()}
                     className="schedule-button academic-button px-4 py-3 rounded-full flex items-center justify-center space-x-2 animate-academic-glow"
+                    data-ph-event="floating_schedule_now_click"
                 >
                     <Calendar className="w-5 h-5" />
                     <span className="font-semibold">Schedule Now</span>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -110,6 +110,7 @@ export default function Hero () {
                         <button
                             onClick={() => open()}
                             className="schedule-trigger academic-button px-8 py-4 text-lg font-semibold rounded-lg flex items-center space-x-2 w-full sm:w-auto"
+                            data-ph-event="hero_schedule_free_consultation_click"
                         >
                             <span>Schedule Free Consultation</span>
                             <ArrowRight className="w-5 h-5" />
@@ -120,6 +121,7 @@ export default function Hero () {
                                 if (element) element.scrollIntoView({ behavior: 'smooth' })
                             }}
                             className="px-8 py-4 text-lg font-semibold rounded-lg border-2 border-academic-navy/20 dark:border-white/20 text-foreground dark:text-white hover:border-academic-gold/50 hover:bg-academic-gold/10 transition-all duration-300 w-full sm:w-auto"
+                            data-ph-event="hero_view_services_click"
                         >
                             View Services
                         </button>

--- a/src/components/Pricing.tsx
+++ b/src/components/Pricing.tsx
@@ -31,6 +31,7 @@ export default function Pricing () {
           onClick={() => open('https://cal.com/thebayarea/consultation?embed=1')}
           variant="primary"
           className="schedule-trigger"
+          phEvent="pricing_schedule_now_click"
         >
           Schedule Now
         </Button>

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -20,6 +20,7 @@ export default function ThemeToggle () {
             onClick={toggleTheme}
             aria-label="Toggle dark mode"
             className="p-2 rounded focus:outline-none focus:ring-2 focus:ring-academic-gold"
+            data-ph-event="theme_toggle_click"
         >
             {resolvedTheme === 'dark'
                 ? <Sun className="w-5 h-5 text-academic-gold" />

--- a/src/components/sections/ContactCTA.tsx
+++ b/src/components/sections/ContactCTA.tsx
@@ -239,6 +239,7 @@ const ContactCTA = ({ heading, subheading, email, phone, availability, ctaText }
                                                     type="submit"
                                                     className="w-full py-3 px-6 bg-yellow-600 hover:bg-yellow-700 text-white font-medium rounded-md transition-colors disabled:opacity-75"
                                                     disabled={isSubmitting}
+                                                    data-ph-event="contact_form_submit"
                                                 >
                                                     {isSubmitting ? 'Submitting...' : ctaText}
                                                 </button>

--- a/src/components/sections/FAQ.tsx
+++ b/src/components/sections/FAQ.tsx
@@ -30,6 +30,7 @@ const FAQSection = ({ heading, subheading, faqs }: FAQProps) => {
                     <a
                         href="#schedule"
                         className="inline-block py-2 px-6 text-navy-800 border border-navy-800 rounded-md font-medium hover:bg-navy-800 hover:text-white transition-colors"
+                        data-ph-event="faq_contact_direct_click"
                     >
                         Contact me directly
                     </a>

--- a/src/components/sections/LocationMap.tsx
+++ b/src/components/sections/LocationMap.tsx
@@ -154,6 +154,7 @@ const LocationMap = ({
                                 <a
                                     href="#schedule"
                                     className="inline-block w-full text-center py-2 bg-yellow-600 text-white rounded-md font-medium hover:bg-yellow-700 transition-colors"
+                                    data-ph-event="location_schedule_here_click"
                                 >
                                     Schedule Here
                                 </a>
@@ -165,6 +166,7 @@ const LocationMap = ({
                         <p className="text-navy-600 mb-4">Can't find a convenient location? I'm flexible and may be able to meet at other libraries or quiet study spaces in the Bay Area.</p>
                         <button
                             className="bg-navy-700 hover:bg-navy-800 text-white font-medium py-3 px-6 rounded-md transition-colors"
+                            data-ph-event="location_cta_click"
                         >
                             {ctaText}
                         </button>

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -10,6 +10,8 @@ interface ButtonProps {
     type?: 'button' | 'submit' | 'reset';
     disabled?: boolean;
     className?: string;
+    phEvent?: string;
+    phLabel?: string;
 }
 
 const Button = ({
@@ -22,6 +24,8 @@ const Button = ({
                     type = 'button',
                     disabled = false,
                     className = '',
+                    phEvent,
+                    phLabel,
                 }: ButtonProps) => {
     // Base classes
     const baseClasses = 'font-medium rounded-md transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2';
@@ -58,6 +62,8 @@ const Button = ({
                 href={href}
                 className={combinedClasses}
                 onClick={onClick}
+                data-ph-event={phEvent}
+                data-ph-label={phLabel}
             >
                 {children}
             </a>
@@ -71,6 +77,8 @@ const Button = ({
             className={combinedClasses}
             onClick={onClick}
             disabled={disabled}
+            data-ph-event={phEvent}
+            data-ph-label={phLabel}
         >
             {children}
         </button>

--- a/src/components/ui/FAQItem.tsx
+++ b/src/components/ui/FAQItem.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from 'react';
 import { FAQ } from '@/types';
+import { createSlug } from '@/utils/formatters';
+import { captureEvent } from '../../../analytics/utils';
 
 interface FAQItemProps {
     faq: FAQ;
@@ -14,7 +16,15 @@ const FAQItem = ({ faq }: FAQItemProps) => {
         <div className="border-b border-gray-200 last:border-b-0">
             <button
                 className="flex justify-between items-center w-full py-4 text-left"
-                onClick={() => setIsOpen(!isOpen)}
+                onClick={() => {
+                    const opening = !isOpen;
+                    setIsOpen(opening);
+                    captureEvent(`faq_toggle_${createSlug(faq.question)}`, {
+                        faq_id: faq.id,
+                        question: faq.question,
+                        state: opening ? 'open' : 'close',
+                    });
+                }}
                 aria-expanded={isOpen}
             >
                 <h3 className="text-lg font-medium text-navy-800">{faq.question}</h3>

--- a/src/components/ui/PricingCard.tsx
+++ b/src/components/ui/PricingCard.tsx
@@ -45,6 +45,8 @@ const PricingCard = ({ plan }: PricingCardProps) => {
                     fullWidth
                     onClick={() => open('https://cal.com/thebayarea/1-hour-session?embed=1')}
                     className="schedule-trigger"
+                    phEvent={`pricing_plan_${plan.id}_select`}
+                    phLabel={plan.name}
                 >
                     {plan.cta}
                 </Button>


### PR DESCRIPTION
## Summary
- capture `data-ph-event` clicks in analytics hook for flexible custom events
- emit descriptive PostHog events for FAQ toggles and CTA buttons
- expose `phEvent`/`phLabel` props on shared Button component

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx jest` *(fails: Cannot find module 'lucide-react' from 'src/components/Header.tsx')*

------
https://chatgpt.com/codex/tasks/task_e_68b1b998bfe08325b59c04611df8df2a