### PR TITLE
Ensure PostHog recordings stay enabled

### DIFF
--- a/analytics/consent.js
+++ b/analytics/consent.js
@@ -1,0 +1,32 @@
+const CONSENT_KEY = 'ph_consent'
+
+function hasLocalStorageSupport () {
+    try {
+        return typeof window !== 'undefined' && typeof window.localStorage !== 'undefined'
+    } catch {
+        return false
+    }
+}
+
+export function setRecordingConsent (value) {
+    if (!hasLocalStorageSupport()) return
+
+    try {
+        window.localStorage.setItem(CONSENT_KEY, value ? 'true' : 'false')
+    } catch (error) {
+        console.error('Failed to persist PostHog consent', error)
+    }
+}
+
+export function hasRecordingConsent () {
+    if (!hasLocalStorageSupport()) return true
+
+    try {
+        const stored = window.localStorage.getItem(CONSENT_KEY)
+        return stored !== 'false'
+    } catch {
+        return true
+    }
+}
+
+export { CONSENT_KEY }

--- a/analytics/posthog.config.js
+++ b/analytics/posthog.config.js
@@ -1,4 +1,5 @@
 import posthog from 'posthog-js'
+import { hasRecordingConsent } from './consent.js'
 
 const POSTHOG_KEY = 'phc_VZX1tioRIHsGxMdBVLlW7PEKGOw13antIazxQHTM7V0'
 const POSTHOG_HOST = 'https://us.posthog.com'
@@ -6,16 +7,16 @@ const POSTHOG_HOST = 'https://us.posthog.com'
 const isProd = process.env.NODE_ENV === 'production'
 let initialized = false
 
-function hasConsent () {
-    try {
-        return localStorage.getItem('ph_consent') === 'true'
-    } catch {
-        return false
+function ensureSessionRecording () {
+    if (typeof posthog?.sessionRecording?.startRecording === 'function') {
+        posthog.sessionRecording.startRecording()
+    } else if (typeof posthog?.startSessionRecording === 'function') {
+        posthog.startSessionRecording()
     }
 }
 
 export function initPostHog () {
-    if (typeof window === 'undefined' || initialized || !hasConsent()) return
+    if (typeof window === 'undefined' || initialized || !hasRecordingConsent()) return
     try {
         posthog.init(POSTHOG_KEY, {
             api_host: POSTHOG_HOST,
@@ -28,6 +29,7 @@ export function initPostHog () {
             },
             debug: !isProd,
         })
+        ensureSessionRecording()
         initialized = true
     } catch (error) {
         console.error('PostHog initialization failed', error)

--- a/analytics/utils.js
+++ b/analytics/utils.js
@@ -1,8 +1,16 @@
 import posthog from 'posthog-js'
 import { initPostHog } from './posthog.config.js'
+import { hasRecordingConsent, setRecordingConsent } from './consent.js'
 
-const CONSENT_KEY = 'ph_consent'
 let pageStart = Date.now()
+
+function ensureSessionRecording () {
+    if (typeof posthog?.sessionRecording?.startRecording === 'function') {
+        posthog.sessionRecording.startRecording()
+    } else if (typeof posthog?.startSessionRecording === 'function') {
+        posthog.startSessionRecording()
+    }
+}
 
 export function captureEvent (name, properties = {}) {
     try {
@@ -38,22 +46,26 @@ export function setupErrorTracking () {
 }
 
 export function grantConsent () {
-    localStorage.setItem(CONSENT_KEY, 'true')
+    setRecordingConsent(true)
     posthog.opt_in_capturing()
     initPostHog()
+    ensureSessionRecording()
+    captureEvent('posthog_consent_granted', { timestamp: Date.now() })
 }
 
 export function revokeConsent () {
-    localStorage.setItem(CONSENT_KEY, 'false')
+    captureEvent('posthog_consent_revoked', { timestamp: Date.now() })
+    setRecordingConsent(false)
     posthog.opt_out_capturing()
+    if (typeof posthog?.sessionRecording?.stopRecording === 'function') {
+        posthog.sessionRecording.stopRecording()
+    } else if (typeof posthog?.stopSessionRecording === 'function') {
+        posthog.stopSessionRecording()
+    }
 }
 
 export function hasConsent () {
-    try {
-        return localStorage.getItem(CONSENT_KEY) === 'true'
-    } catch {
-        return false
-    }
+    return hasRecordingConsent()
 }
 
 export function trackPerformance () {


### PR DESCRIPTION
## Summary
- ensure PostHog initialization only respects explicit opt-outs and centralize consent helpers
- automatically restart session recordings whenever consent is granted or initialization runs
- capture explicit analytics events for PostHog consent changes to track configuration health

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690ea4de11d0832599cc250a1d09e827)