### PR TITLE
Add PostHog tracking for interactive UI elements

### DIFF
--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -109,6 +109,7 @@ export default function Contact () {
                                 onClick={() => open()}
                                 className="schedule-trigger academic-button px-6 py-4 text-lg font-semibold rounded-lg flex items-center justify-center space-x-2 mx-auto"
                                 data-ph-event="contact_schedule_now_click"
+                                data-ph-label="schedule_now"
                             >
                                 <Calendar className="w-5 h-5" />
                                 <span>Schedule Now</span>

--- a/src/components/FAQ.tsx
+++ b/src/components/FAQ.tsx
@@ -56,33 +56,40 @@ export default function FAQ () {
                     </div>
 
                     <div className="space-y-4">
-                        {faqs.map((faq, index) => (
-                            <div key={index} className="academic-card academic-hover">
-                                <button
-                                    onClick={() => toggleItem(index)}
-                                    className="w-full p-6 text-left flex items-center justify-between focus:outline-none"
-                                >
-                                    <h3 className="text-lg font-semibold text-foreground dark:text-white pr-4 title-font">
-                                        {faq.question}
-                                    </h3>
-                                    <div className="text-academic-gold flex-shrink-0">
-                                        {openItem === index ? (
-                                            <ChevronUp className="w-6 h-6" />
-                                        ) : (
-                                            <ChevronDown className="w-6 h-6" />
-                                        )}
-                                    </div>
-                                </button>
+                        {faqs.map((faq, index) => {
+                            const faqId = createSlug(faq.question)
+                            const isOpen = openItem === index
+                            return (
+                                <div key={index} className="academic-card academic-hover">
+                                    <button
+                                        onClick={() => toggleItem(index)}
+                                        className="w-full p-6 text-left flex items-center justify-between focus:outline-none"
+                                        data-faq-id={faqId}
+                                        data-ph-event={`faq_toggle_${faqId}`}
+                                        data-ph-label={isOpen ? 'collapse' : 'expand'}
+                                    >
+                                        <h3 className="text-lg font-semibold text-foreground dark:text-white pr-4 title-font">
+                                            {faq.question}
+                                        </h3>
+                                        <div className="text-academic-gold flex-shrink-0">
+                                            {isOpen ? (
+                                                <ChevronUp className="w-6 h-6" />
+                                            ) : (
+                                                <ChevronDown className="w-6 h-6" />
+                                            )}
+                                        </div>
+                                    </button>
 
-                                <div className={`faq-content ${openItem === index ? 'open' : ''}`}>
-                                    <div className="px-6 pb-6">
-                                        <p className="text-academic-medium-blue dark:text-academic-off-white leading-relaxed">
-                                            {faq.answer}
-                                        </p>
+                                    <div className={`faq-content ${isOpen ? 'open' : ''}`}>
+                                        <div className="px-6 pb-6">
+                                            <p className="text-academic-medium-blue dark:text-academic-off-white leading-relaxed">
+                                                {faq.answer}
+                                            </p>
+                                        </div>
                                     </div>
                                 </div>
-                            </div>
-                        ))}
+                            )
+                        })}
                     </div>
 
                     <div className="mt-12 text-center">
@@ -98,6 +105,7 @@ export default function FAQ () {
                                 }}
                                 className="academic-button px-6 py-3 font-semibold rounded-lg"
                                 data-ph-event="faq_ask_question_click"
+                                data-ph-label="ask_question"
                             >
                                 Ask Your Question
                             </button>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -32,13 +32,23 @@ export default function Footer () {
                         <div className="space-y-3">
                             <div className="flex items-center space-x-3">
                                 <Phone className="w-5 h-5 text-academic-gold" />
-                <a href="tel:(925)237-1327" className="hover:text-academic-gold transition-colors font-medium">
+                                <a
+                                    href="tel:(925)237-1327"
+                                    className="hover:text-academic-gold transition-colors font-medium"
+                                    data-ph-event="footer_phone_click"
+                                    data-ph-label="(925) 237-1327"
+                                >
                                     (925) 237-1327
                                 </a>
                             </div>
                             <div className="flex items-center space-x-3">
                                 <Mail className="w-5 h-5 text-academic-gold" />
-                                <a href="mailto:amir@thebayareatutor.com" className="hover:text-academic-gold transition-colors font-medium">
+                                <a
+                                    href="mailto:amir@thebayareatutor.com"
+                                    className="hover:text-academic-gold transition-colors font-medium"
+                                    data-ph-event="footer_email_click"
+                                    data-ph-label="amir@thebayareatutor.com"
+                                >
                                     amir@thebayareatutor.com
                                 </a>
                             </div>
@@ -58,6 +68,7 @@ export default function Footer () {
                                     onClick={() => scrollToSection('services')}
                                     className="text-academic-medium-blue dark:text-academic-off-white hover:text-academic-gold transition-colors text-sm"
                                     data-ph-event="footer_test_preparation_click"
+                                    data-ph-label="test_preparation"
                                 >
                                     Test Preparation
                                 </button>
@@ -67,6 +78,7 @@ export default function Footer () {
                                     onClick={() => scrollToSection('services')}
                                     className="text-academic-medium-blue dark:text-academic-off-white hover:text-academic-gold transition-colors text-sm"
                                     data-ph-event="footer_academic_support_click"
+                                    data-ph-label="academic_support"
                                 >
                                     Academic Support
                                 </button>
@@ -76,6 +88,7 @@ export default function Footer () {
                                     onClick={() => scrollToSection('services')}
                                     className="text-academic-medium-blue dark:text-academic-off-white hover:text-academic-gold transition-colors text-sm"
                                     data-ph-event="footer_personalized_learning_click"
+                                    data-ph-label="personalized_learning"
                                 >
                                     Personalized Learning
                                 </button>
@@ -85,6 +98,7 @@ export default function Footer () {
                                     onClick={() => scrollToSection('contact')}
                                     className="text-academic-medium-blue dark:text-academic-off-white hover:text-academic-gold transition-colors text-sm"
                                     data-ph-event="footer_free_consultation_click"
+                                    data-ph-label="free_consultation"
                                 >
                                     Free Consultation
                                 </button>
@@ -120,6 +134,7 @@ export default function Footer () {
                             onClick={scrollToTop}
                             className="flex items-center space-x-2 text-academic-medium-blue dark:text-academic-off-white hover:text-academic-gold transition-colors text-sm"
                             data-ph-event="footer_back_to_top_click"
+                            data-ph-label="back_to_top"
                         >
                             <span>Back to Top</span>
                             <ArrowUp className="w-4 h-4" />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -75,6 +75,7 @@ export default function Header () {
                                 onClick={() => scrollToSection('services')}
                                 className="text-academic-navy dark:text-white hover:text-academic-gold transition-colors font-medium"
                                 data-ph-event="nav_services_click"
+                                data-ph-label="services"
                             >
                                 Services
                             </button>
@@ -82,6 +83,7 @@ export default function Header () {
                                 onClick={() => scrollToSection('about')}
                                 className="text-academic-navy dark:text-white hover:text-academic-gold transition-colors font-medium"
                                 data-ph-event="nav_about_click"
+                                data-ph-label="about"
                             >
                                 About
                             </button>
@@ -89,6 +91,7 @@ export default function Header () {
                                 onClick={() => scrollToSection('faq')}
                                 className="text-academic-navy dark:text-white hover:text-academic-gold transition-colors font-medium"
                                 data-ph-event="nav_faq_click"
+                                data-ph-label="faq"
                             >
                                 FAQ
                             </button>
@@ -97,6 +100,7 @@ export default function Header () {
                                 data-action="schedule_now"
                                 className="schedule-trigger academic-button px-6 py-2 text-sm font-semibold rounded-md flex items-center space-x-2"
                                 data-ph-event="nav_schedule_now_click"
+                                data-ph-label="schedule_now"
                             >
                                 <Calendar className="w-4 h-4" />
                                 <span>Schedule Now</span>
@@ -109,6 +113,7 @@ export default function Header () {
                             onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
                             className="lg:hidden text-academic-navy dark:text-white p-2"
                             data-ph-event="nav_mobile_menu_toggle"
+                            data-ph-label={isMobileMenuOpen ? 'close_menu' : 'open_menu'}
                         >
                             {isMobileMenuOpen ? <X className="w-6 h-6" /> : <Menu className="w-6 h-6" />}
                         </button>
@@ -121,6 +126,7 @@ export default function Header () {
                                 onClick={() => scrollToSection('services')}
                                 className="block w-full text-left text-academic-navy dark:text-white hover:text-academic-gold transition-colors font-medium py-2"
                                 data-ph-event="mobile_nav_services_click"
+                                data-ph-label="services"
                             >
                                 Services
                             </button>
@@ -128,6 +134,7 @@ export default function Header () {
                                 onClick={() => scrollToSection('about')}
                                 className="block w-full text-left text-academic-navy dark:text-white hover:text-academic-gold transition-colors font-medium py-2"
                                 data-ph-event="mobile_nav_about_click"
+                                data-ph-label="about"
                             >
                                 About
                             </button>
@@ -135,6 +142,7 @@ export default function Header () {
                                 onClick={() => scrollToSection('faq')}
                                 className="block w-full text-left text-academic-navy dark:text-white hover:text-academic-gold transition-colors font-medium py-2"
                                 data-ph-event="mobile_nav_faq_click"
+                                data-ph-label="faq"
                             >
                                 FAQ
                             </button>
@@ -143,6 +151,7 @@ export default function Header () {
                                 data-action="schedule_now"
                                 className="schedule-trigger academic-button w-full px-4 py-2 text-sm font-semibold rounded-md flex items-center justify-center space-x-2"
                                 data-ph-event="mobile_nav_schedule_now_click"
+                                data-ph-label="schedule_now"
                             >
                                 <Calendar className="w-4 h-4" />
                                 <span>Schedule Now</span>
@@ -161,6 +170,7 @@ export default function Header () {
                     onClick={() => handleScheduleClick()}
                     className="schedule-button academic-button px-4 py-3 rounded-full flex items-center justify-center space-x-2 animate-academic-glow"
                     data-ph-event="floating_schedule_now_click"
+                    data-ph-label="schedule_now"
                 >
                     <Calendar className="w-5 h-5" />
                     <span className="font-semibold">Schedule Now</span>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -111,6 +111,7 @@ export default function Hero () {
                             onClick={() => open()}
                             className="schedule-trigger academic-button px-8 py-4 text-lg font-semibold rounded-lg flex items-center space-x-2 w-full sm:w-auto"
                             data-ph-event="hero_schedule_free_consultation_click"
+                            data-ph-label="schedule_free_consultation"
                         >
                             <span>Schedule Free Consultation</span>
                             <ArrowRight className="w-5 h-5" />
@@ -122,6 +123,7 @@ export default function Hero () {
                             }}
                             className="px-8 py-4 text-lg font-semibold rounded-lg border-2 border-academic-navy/20 dark:border-white/20 text-foreground dark:text-white hover:border-academic-gold/50 hover:bg-academic-gold/10 transition-all duration-300 w-full sm:w-auto"
                             data-ph-event="hero_view_services_click"
+                            data-ph-label="view_services"
                         >
                             View Services
                         </button>

--- a/src/components/Pricing.tsx
+++ b/src/components/Pricing.tsx
@@ -32,6 +32,7 @@ export default function Pricing () {
           variant="primary"
           className="schedule-trigger"
           phEvent="pricing_schedule_now_click"
+          phLabel="schedule_now"
         >
           Schedule Now
         </Button>

--- a/src/components/Testimonials.tsx
+++ b/src/components/Testimonials.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react'
 import { ChevronLeft, ChevronRight, Quote } from 'lucide-react'
 
 import { siteContent } from '@/data/siteContent'
+import { captureEvent } from '../../analytics/utils'
 
 export default function Testimonials () {
     const { heading, subheading, items } = siteContent.testimonials
@@ -28,11 +29,32 @@ export default function Testimonials () {
     const currentTestimonial = items[currentIndex]
 
     const handlePrevious = () => {
-        setCurrentIndex((prev) => (prev - 1 + items.length) % items.length)
+        const nextIndex = (currentIndex - 1 + items.length) % items.length
+        captureEvent('testimonials_previous_click', {
+            current_index: currentIndex,
+            next_index: nextIndex,
+            testimonial_name: items[nextIndex]?.name,
+        })
+        setCurrentIndex(nextIndex)
     }
 
     const handleNext = () => {
-        setCurrentIndex((prev) => (prev + 1) % items.length)
+        const nextIndex = (currentIndex + 1) % items.length
+        captureEvent('testimonials_next_click', {
+            current_index: currentIndex,
+            next_index: nextIndex,
+            testimonial_name: items[nextIndex]?.name,
+        })
+        setCurrentIndex(nextIndex)
+    }
+
+    const handleSelect = (index: number) => {
+        captureEvent('testimonials_pagination_select', {
+            current_index: currentIndex,
+            next_index: index,
+            testimonial_name: items[index]?.name,
+        })
+        setCurrentIndex(index)
     }
 
     return (
@@ -67,6 +89,8 @@ export default function Testimonials () {
                                 onClick={handlePrevious}
                                 className="inline-flex h-12 w-12 items-center justify-center rounded-full border border-academic-gold text-academic-gold hover:bg-academic-gold hover:text-academic-navy transition-colors"
                                 aria-label="Show previous testimonial"
+                                data-ph-event="testimonials_previous_click"
+                                data-ph-label={currentTestimonial.name}
                             >
                                 <ChevronLeft className="h-6 w-6" />
                             </button>
@@ -76,9 +100,11 @@ export default function Testimonials () {
                                         <button
                                             key={index}
                                             type="button"
-                                            onClick={() => setCurrentIndex(index)}
+                                            onClick={() => handleSelect(index)}
                                             className={`h-2.5 w-3 sm:w-4 rounded-full transition-all ${index === currentIndex ? 'bg-academic-gold' : 'bg-academic-gold/30'}`}
                                             aria-label={`Show testimonial ${index + 1}`}
+                                            data-ph-event="testimonials_pagination_click"
+                                            data-ph-label={items[index]?.name}
                                         />
                                     ))}
                                 </div>
@@ -88,6 +114,8 @@ export default function Testimonials () {
                                 onClick={handleNext}
                                 className="inline-flex h-12 w-12 items-center justify-center rounded-full border border-academic-gold text-academic-gold hover:bg-academic-gold hover:text-academic-navy transition-colors"
                                 aria-label="Show next testimonial"
+                                data-ph-event="testimonials_next_click"
+                                data-ph-label={currentTestimonial.name}
                             >
                                 <ChevronRight className="h-6 w-6" />
                             </button>


### PR DESCRIPTION
## Summary
- add PostHog event metadata to navigation, call-to-action, and contact elements for consistent analytics coverage
- instrument FAQ toggles and testimonial carousel controls with detailed PostHog capture events
- tag pricing and hero CTAs with descriptive labels for downstream analysis

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690ea9f7339c8325b3fe148ac7c0587b)