### PR TITLE
Reimagine landing as clkly link shortener

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "crypto-js": "^4.2.0",
         "eslint-config-next": "13.4.6",
         "framer-motion": "^10.16.4",
+        "googleapis": "^140.0.1",
         "next": "^14.2.21",
         "postcss": "^8.4.31",
         "posthog-js": "^1.298.1",
@@ -3879,6 +3880,28 @@
         "@img/sharp-libvips-darwin-arm64": "1.0.4"
       }
     },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
+      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.0.4"
+      }
+    },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
@@ -3891,6 +3914,304 @@
       "os": [
         "darwin"
       ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
+      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
+      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
+      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
+      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
+      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
+      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
+      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
+      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.0.5"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
+      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
+      "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
+      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
+      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
+      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
+      "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
+      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
+      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -7318,7 +7639,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -7352,6 +7672,15 @@
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
       "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
       "engines": {
         "node": "*"
       }
@@ -7594,6 +7923,12 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -8686,6 +9021,15 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.76",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.76.tgz",
@@ -9612,6 +9956,12 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -10010,6 +10360,58 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/gaxios": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gaxios/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/gaxios/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -10178,6 +10580,62 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/googleapis": {
+      "version": "140.0.1",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-140.0.1.tgz",
+      "integrity": "sha512-ZGvBX4mQcFXO9ACnVNg6Aqy3KtBPB5zTuue43YVLxwn8HSv8jB7w+uDKoIPSoWuxGROgnj2kbng6acXncOQRNA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^9.0.0",
+        "googleapis-common": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/googleapis-common": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-7.2.0.tgz",
+      "integrity": "sha512-/fhDZEJZvOV3X5jmD+fKxMqma5q2Q9nZNSF3kn1F18tpxmA86BcTxAGBQdM0N89Z3bEaIs+HVznSmFJEAmMTjA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "gaxios": "^6.0.3",
+        "google-auth-library": "^9.7.0",
+        "qs": "^6.7.0",
+        "url-template": "^2.0.8",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
@@ -10198,6 +10656,19 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag=="
+    },
+    "node_modules/gtoken": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/has": {
       "version": "1.0.3",
@@ -10947,6 +11418,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-string": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
@@ -11185,18 +11668,6 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/jest-changed-files/node_modules/is-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/jest-circus": {
@@ -11844,6 +12315,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -11901,6 +12381,27 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+      "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.0",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/kleur": {
@@ -13442,7 +13943,6 @@
       "version": "6.13.1",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.1.tgz",
       "integrity": "sha512-EJPeIn0CYrGu+hli1xilKAPXODtJ12T0sP63Ijx2/khC2JtuaN3JyNIpvmnkmaEtha9ocbG4A4cMcr+TvqvwQg==",
-      "dev": true,
       "dependencies": {
         "side-channel": "^1.0.6"
       },
@@ -14110,7 +14610,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -15443,6 +15942,12 @@
         "requires-port": "^1.0.0"
       }
     },
+    "node_modules/url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
+      "license": "BSD"
+    },
     "node_modules/url/node_modules/punycode": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
@@ -15518,7 +16023,6 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
       "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -15981,333 +16485,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
-      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
-      "optional": true,
-      "dev": true,
-      "os": [
-        "darwin"
-      ],
-      "cpu": [
-        "x64"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.0.4"
-      }
-    },
-    "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
-      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
-      "optional": true,
-      "dev": true,
-      "os": [
-        "darwin"
-      ],
-      "cpu": [
-        "x64"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
-      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
-      "optional": true,
-      "dev": true,
-      "os": [
-        "linux"
-      ],
-      "cpu": [
-        "arm"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
-      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
-      "optional": true,
-      "dev": true,
-      "os": [
-        "linux"
-      ],
-      "cpu": [
-        "arm64"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
-      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
-      "optional": true,
-      "dev": true,
-      "os": [
-        "linux"
-      ],
-      "cpu": [
-        "s390x"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
-      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
-      "optional": true,
-      "dev": true,
-      "os": [
-        "linux"
-      ],
-      "cpu": [
-        "x64"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
-      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
-      "optional": true,
-      "dev": true,
-      "os": [
-        "linux"
-      ],
-      "cpu": [
-        "arm64"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
-      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
-      "optional": true,
-      "dev": true,
-      "os": [
-        "linux"
-      ],
-      "cpu": [
-        "x64"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-linux-arm": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
-      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
-      "optional": true,
-      "dev": true,
-      "os": [
-        "linux"
-      ],
-      "cpu": [
-        "arm"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.0.5"
-      }
-    },
-    "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
-      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
-      "optional": true,
-      "dev": true,
-      "os": [
-        "linux"
-      ],
-      "cpu": [
-        "arm64"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.0.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
-      "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
-      "optional": true,
-      "dev": true,
-      "os": [
-        "linux"
-      ],
-      "cpu": [
-        "s390x"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.0.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
-      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
-      "optional": true,
-      "dev": true,
-      "os": [
-        "linux"
-      ],
-      "cpu": [
-        "x64"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.0.4"
-      }
-    },
-    "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
-      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
-      "optional": true,
-      "dev": true,
-      "os": [
-        "linux"
-      ],
-      "cpu": [
-        "arm64"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
-      }
-    },
-    "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
-      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
-      "optional": true,
-      "dev": true,
-      "os": [
-        "linux"
-      ],
-      "cpu": [
-        "x64"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
-      }
-    },
-    "node_modules/@img/sharp-wasm32": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
-      "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
-      "optional": true,
-      "dev": true,
-      "cpu": [
-        "wasm32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
-      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
-      "optional": true,
-      "dev": true,
-      "os": [
-        "win32"
-      ],
-      "cpu": [
-        "ia32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-win32-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
-      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
-      "optional": true,
-      "dev": true,
-      "os": [
-        "win32"
-      ],
-      "cpu": [
-        "x64"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.7.1.tgz",
-      "integrity": "sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA==",
-      "optional": true,
-      "dev": true
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "framer-motion": "^10.16.4",
         "next": "^14.2.21",
         "postcss": "^8.4.31",
+        "posthog-js": "^1.298.1",
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-icons": "^4.11.0",
@@ -4630,6 +4631,15 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
+    "node_modules/@posthog/core": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.6.0.tgz",
+      "integrity": "sha512-Tbh8UACwbb7jFdDC7wwXHtfNzO+4wKh3VbyMHmp2UBe6w1jliJixexTJNfkqdGZm+ht3M10mcKvGGPnoZ2zLBg==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.6"
+      }
+    },
     "node_modules/@rushstack/eslint-patch": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.3.2.tgz",
@@ -8010,6 +8020,17 @@
         "toggle-selection": "^1.0.6"
       }
     },
+    "node_modules/core-js": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.47.0.tgz",
+      "integrity": "sha512-c3Q2VVkGAUyupsjRnaNX6u8Dq2vAdzm9iuPj5FW0fRxzlxgq9Q39MDq10IvmQSpLgHQNyQzQmOo6bgGHmH3NNg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/core-js-compat": {
       "version": "3.39.0",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.39.0.tgz",
@@ -9666,6 +9687,12 @@
       "dependencies": {
         "bser": "2.1.1"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
+      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
@@ -13223,6 +13250,29 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
     },
+    "node_modules/posthog-js": {
+      "version": "1.298.1",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.298.1.tgz",
+      "integrity": "sha512-MynFhC2HO6sg5moUfpkd0s6RzAqcqFX75kjIi4Xrj2Gl0/YQWYvFUgvv8FCpWPKPs2mdvNWYhs+oqJg0BVVHPw==",
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@posthog/core": "1.6.0",
+        "core-js": "^3.38.1",
+        "fflate": "^0.4.8",
+        "preact": "^10.19.3",
+        "web-vitals": "^4.2.4"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.27.2",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.27.2.tgz",
+      "integrity": "sha512-5SYSgFKSyhCbk6SrXyMpqjb5+MQBgfvEKE/OC+PujcY34sOpqtr+0AZQtPYx5IA6VxynQ7rUPCtKzyovpj9Bpg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -15530,6 +15580,12 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/web-vitals": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
+      "integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==",
+      "license": "Apache-2.0"
     },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15981,6 +15981,333 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
+      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "optional": true,
+      "dev": true,
+      "os": [
+        "darwin"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
+      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "optional": true,
+      "dev": true,
+      "os": [
+        "darwin"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
+      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "optional": true,
+      "dev": true,
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "arm"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
+      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "optional": true,
+      "dev": true,
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
+      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
+      "optional": true,
+      "dev": true,
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "s390x"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
+      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "optional": true,
+      "dev": true,
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
+      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "optional": true,
+      "dev": true,
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
+      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "optional": true,
+      "dev": true,
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
+      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "optional": true,
+      "dev": true,
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "arm"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.0.5"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
+      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "optional": true,
+      "dev": true,
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
+      "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
+      "optional": true,
+      "dev": true,
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "s390x"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
+      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "optional": true,
+      "dev": true,
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
+      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "optional": true,
+      "dev": true,
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
+      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "optional": true,
+      "dev": true,
+      "os": [
+        "linux"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
+      "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
+      "optional": true,
+      "dev": true,
+      "cpu": [
+        "wasm32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
+      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
+      "optional": true,
+      "dev": true,
+      "os": [
+        "win32"
+      ],
+      "cpu": [
+        "ia32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
+      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "optional": true,
+      "dev": true,
+      "os": [
+        "win32"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.7.1.tgz",
+      "integrity": "sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA==",
+      "optional": true,
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "crypto-js": "^4.2.0",
     "eslint-config-next": "13.4.6",
     "framer-motion": "^10.16.4",
+    "googleapis": "^140.0.1",
     "next": "^14.2.21",
     "postcss": "^8.4.31",
     "posthog-js": "^1.298.1",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "framer-motion": "^10.16.4",
     "next": "^14.2.21",
     "postcss": "^8.4.31",
+    "posthog-js": "^1.298.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-icons": "^4.11.0",

--- a/src/app/api/links/route.ts
+++ b/src/app/api/links/route.ts
@@ -1,0 +1,108 @@
+import { NextResponse } from 'next/server';
+import { appendLinkRow, fetchLinksFromSheet, LinkRow } from '@/lib/sheets';
+
+export const dynamic = 'force-dynamic';
+
+function baseHost() {
+  return process.env.SHORT_LINK_BASE_URL || 'https://clk.ly';
+}
+
+function sanitizeAlias(alias?: string) {
+  if (!alias) return '';
+  return alias
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, '-')
+    .replace(/[^a-z0-9-_]/g, '');
+}
+
+function authorize(request: Request) {
+  const user = process.env.LINKS_API_USER;
+  const password = process.env.LINKS_API_PASSWORD;
+
+  if (!user || !password) {
+    return { authorized: true };
+  }
+
+  const header = request.headers.get('authorization');
+  if (!header?.startsWith('Basic ')) {
+    return { authorized: false, response: NextResponse.json({ message: 'Unauthorized' }, { status: 401 }) };
+  }
+
+  const decoded = Buffer.from(header.replace('Basic ', ''), 'base64').toString('utf8');
+  const [providedUser, providedPassword] = decoded.split(':');
+  const authorized = providedUser === user && providedPassword === password;
+
+  if (!authorized) {
+    return { authorized: false, response: NextResponse.json({ message: 'Unauthorized' }, { status: 401 }) };
+  }
+
+  return { authorized: true };
+}
+
+async function readRequestBody(request: Request) {
+  try {
+    return await request.json();
+  } catch (error) {
+    return null;
+  }
+}
+
+export async function GET(request: Request) {
+  const authz = authorize(request);
+  if (!authz.authorized) return authz.response;
+
+  try {
+    const links = await fetchLinksFromSheet();
+    return NextResponse.json({ links });
+  } catch (error) {
+    return NextResponse.json(
+      { message: 'Unable to fetch links from the sheet', details: error instanceof Error ? error.message : String(error) },
+      { status: 500 },
+    );
+  }
+}
+
+export async function POST(request: Request) {
+  const authz = authorize(request);
+  if (!authz.authorized) return authz.response;
+
+  const payload = await readRequestBody(request);
+
+  if (!payload || typeof payload.destination !== 'string') {
+    return NextResponse.json({ message: 'Destination URL is required' }, { status: 400 });
+  }
+
+  const sanitizedDestination = payload.destination.trim();
+  const incomingAlias = sanitizeAlias(typeof payload.alias === 'string' ? payload.alias : '');
+  const alias = incomingAlias || `clk-${Math.random().toString(36).slice(2, 8)}`;
+
+  if (!sanitizedDestination) {
+    return NextResponse.json({ message: 'Destination URL is required' }, { status: 400 });
+  }
+
+  try {
+    const existing = await fetchLinksFromSheet();
+    const conflict = existing.find((link) => link.alias === alias);
+    if (conflict) {
+      return NextResponse.json({ message: 'Alias already exists. Please choose another.' }, { status: 409 });
+    }
+
+    const now = new Date().toISOString();
+    const shortUrl = `${baseHost().replace(/\/$/, '')}/${alias}`;
+    const newLink: LinkRow = {
+      alias,
+      destinationUrl: sanitizedDestination,
+      shortUrl,
+      createdAt: now,
+    };
+
+    const persisted = await appendLinkRow(newLink);
+    return NextResponse.json({ link: persisted }, { status: 201 });
+  } catch (error) {
+    return NextResponse.json(
+      { message: 'Unable to create link', details: error instanceof Error ? error.message : String(error) },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,419 +1,403 @@
-@import url('https://fonts.googleapis.com/css?family=Actor');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
 
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
 :root {
-  --foreground-rgb: 255, 255, 255;
-  --background-start-rgb: 0, 0, 0;
-  --background-end-rgb: 0, 0, 0;
+  --bg: #f8fafc;
+  --panel: #ffffff;
+  --text: #0f172a;
+  --muted: #475569;
+  --border: rgba(15, 23, 42, 0.08);
+  --shadow: 0 20px 80px rgba(0, 0, 0, 0.08);
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --foreground-rgb: 255, 255, 255;
-    --background-start-rgb: 0, 0, 0;
-    --background-end-rgb: 0, 0, 0;
-  }
+body[data-theme='dark'] {
+  --bg: #0b1220;
+  --panel: #0f172a;
+  --text: #e2e8f0;
+  --muted: #94a3b8;
+  --border: rgba(148, 163, 184, 0.14);
+  --shadow: 0 20px 80px rgba(0, 0, 0, 0.35);
 }
 
-@keyframes fadeInFromTop {
-  0% {
-    opacity: 0;
-    transform: translateY(-20px);
-  }
-  100% {
-    opacity: 1;
-    transform: translateY(0);
-  }
+* {
+  box-sizing: border-box;
 }
-
-.circle {
-  z-index: 0;
-  display: block;
-  background: white;
-  border-radius: 50%;
-  height: 10px;
-  width: 10px;
-  margin: 0;
-  animation: moveBall 1s ease-in-out;
-}
-
 
 body {
-  overflow-x: hidden;
-  overflow-y: hidden;
-  height: auto;
-  color: rgb(var(--foreground-rgb));
-  background: linear-gradient(
-      to bottom,
-      transparent,
-      rgb(var(--background-end-rgb))
-    )
-    rgb(var(--background-start-rgb));
-}
-
-.times-italic {
-  font-family: 'Times New Roman', Times, serif;
-  font-style: italic;
-}
-
-.times {
-  font-family: 'Times New Roman', Times, serif;
-}
-
-.chalk {
-  align-self: center;
-  font-family: cursive, "Al Tarikh", Menlo;
-}
-
-.button-container {
-  display: flex;
-  justify-content: space-evenly;
-  align-items: center;
-  height: 100vh;
-}
-@keyframes fadeIn {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
-}
-
-.circle-button {
-  position: relative;
-  width: 20vmin;
-  height: 20vmin;
-  border-radius: 50%;
-  border: none;
-  color: white;
-  font-weight: bold;
-  cursor: pointer;
-  animation: fadeIn 1s ease-in-out;
-  box-shadow: 0 0 10px rgba(255, 255, 255, 0.5);
-  transition: width 0.3s ease, height 0.3s ease, box-shadow 0.3s ease, z-index 0.3s ease;
-}
-.circle-button:hover {
-  width: 24vmin;
-  height: 24vmin;
-  z-index: 1;
-  box-shadow: 0 0 20px rgba(255, 255, 255, 0.8);
-}
-
-.button-top-left {
-  margin: 38px;
-  background: black;
-  box-shadow: none;
-  position: absolute;
-  top: 0;
-  right: 0;
-  transform: translate(50%, -50%);
-  transition: all 0.5s ease;
-}
-
-
-.button-top-left:hover {
-    width: 20vmin;
-    height: 20vmin;
-    background: black;
-    box-shadow: none;
-}
-
-.button-top-right {
-  visibility: hidden;
-  top: 0;
-  right: 0;}
-
-.button-return {
-  margin: 20px;
-  height: 10vmin;
-  width: 10vmin;
-  position: absolute;
-  top: 0;
-  left: 0;
-  box-shadow: none;
-}
-
-.button-return:hover {
-  margin: 20px;
-  height: 10vmin;
-  width: 10vmin;
-  position: absolute;
-  top: 0;
-  right: 0;
-}
-
-.menu {
-  animation: fadeIn 1s ease-in-out;
-  transition: width 0.3s ease, height 0.3s ease, box-shadow 0.3s ease, z-index 0.3s ease;
-  margin: 15px;
-  display: flex;
-  flex-direction: column;
-  justify-content: space-around;
-  width: 2rem;
-  height: 2rem;
-  cursor: pointer;
-  position: fixed;
-  right:0;
-  color: #b9b6b6;
-}
-
-.menu-line {
-  width: 80%;
-  height: 0.10rem;
-  background: white;
-}
-
-.menu-line:hover {
-  box-shadow: 0 0 10px rgba(245, 237, 237, 0.91);
-}
-
-.dropdown {
-  position: absolute;
-  right: 80%;
-  top: 100%;
-  background: #000000;
-  color: rgba(255, 255, 255, 0.6);
-  width: 30%;
-  opacity: 1; /* Start invisible */
-  transition: opacity 0.3s ease-in-out; /* Transition effect */
-  white-space:  pre-wrap;
-}
-
-.dropdown-item1 {
-  padding: 10px;
-}
-
-.dropdown-item1:hover{
-  border-bottom: 1px solid white;
-
-}
-
-.dropdown-item2 {
-  padding: 10px;
-}
-
-.dropdown-item2:hover{
-  border-bottom: 1px solid white;
-}
-
-.dropdown-item:last-child {
-  border-bottom: none;
-}
-
-.input-container {
-  display: flex;
-  justify-content: center;
-  justify-self: center;
-  align-items: center;
-  position: absolute;
-  top: 15%;
-  width: 100%;
-}
-
-.rounded-input {
-  background: black;
-  width: 200px;
-  padding: 10px;
-  border-radius: 50px;
-  outline: none;
-  border: 0.5px solid white;
-}
-
-.submit-button {
-  scale: 80%;
-  margin-top: 0.5%;
-  padding: 10px 20px;
-  border-radius: 50px;
-  border: none;
-  cursor: pointer;
-}
-
-.checkmark {
-  margin-left: 4%;
-  color: green;
-  animation: fadeOut 2s ease-in-out forwards;
-}
-
-
-.cross {
-  color: darkred;
-  animation: fadeOut 2s ease-in-out forwards;
-}
-
-@keyframes fadeOut {
-  from {
-    opacity: 1;
-  }
-  to {
-    opacity: 0;
-  }
-}
-
-.close-button {
-    margin-top: 1.5px;
-    scale: 70%;
-    position: relative;
-    box-shadow: 1px 1px 1px 1px rgba(0, 0, 0, 0.2);
-    padding: 30px;
-    cursor: pointer;
-}
-
-.wakeUpContainer {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  height: 100vh;
-  animation: fadeInFromTop 1s ease-in-out;
-}
-
-.wakeUpList {
-  list-style-type: none;
+  margin: 0;
   padding: 0;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+  transition: background 0.3s ease, color 0.3s ease;
 }
 
-.wakeUpTime {
-  font-size: 2rem;
-  text-align: center;
-  margin: 3rem 0;
-  color: rgba(255, 255, 255, 0.19);
-  text-shadow: 0 0 10px rgba(255, 255, 255, 0.17);
+a {
+  color: inherit;
+  text-decoration: none;
 }
 
-.sleepTimeContainer {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  height: 100vh;
-}
-
-.sleepForm {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-}
-
-.sleepLabel {
-  color: white;
-  font-size: 1.5rem;
-  margin-bottom: 1rem;
-  text-shadow: 0 0 10px rgba(255, 255, 255, 0.5);
-  animation: fadeIn 2s ease-in-out;
-}
-
-.dropdownContainer {
-  display: flex;
-  align-items: center;
-  margin-bottom: 1rem;
-}
-
-.small-period {
-  font-size: 0.75rem;
-}
-
-.submitButton {
-  scale: 80%;
-  padding: 10px 20px;
-  border-radius: 50px;
-  border: none;
-  cursor: pointer;
-  background-color: white;
-  color: black;
-  text-shadow: 0 0 10px rgba(255, 255, 255, 0.5);
-  animation: fadeIn 2s ease-in-out;
-}
-
-
-.fade-in-text {
-  text-shadow: 0 0 10px rgba(255, 255, 255, 0.5);
-  font-family: fantasy;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  height: 100vh;
-  text-align: center;
-  animation: fadeIn 2s ease-in-out;
-}
-
-@keyframes fadeInHalf {
-  0% { opacity: 0; }
-  100% { opacity: 0.5; }
-}
-
-@keyframes fadeOutHalf {
-  0% { opacity: 0.5; }
-  100% { opacity: 0; }
-}
-
-
-select {
+.page-shell {
   position: relative;
-  padding: 0.5rem;
-  width: 3rem;
-  height: 110%;
-  border: none;
-  cursor: pointer;
-  animation: fadeIn 1s ease-in-out;
-  box-shadow: 0 4px 6px rgba(246, 244, 244, 0.3), 0 1px 3px rgba(0, 0, 0, 0.1);
-  transition: width 0.3s ease, height 0.3s ease, box-shadow 0.3s ease, z-index 0.3s ease;
-  background: linear-gradient(145deg, #440909, #f1e5e5);
-  appearance: none;
-  border-radius: 20px;
-  background: transparent;
-}
-.calendar {
-  margin-top: 18%;
-  color: white;
-  opacity: 80%;
-  font-family: Optima, sans-serif;
-  text-align: center;
-  animation: fadeIn 2s ease-in-out;
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 48px 24px 72px;
+  overflow: hidden;
 }
 
-.header {
+.grid-backdrop {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: 16px;
+  opacity: 0.9;
+  pointer-events: none;
+  filter: blur(24px);
+  z-index: -1;
+}
+
+.grid-stripe {
+  border-radius: 999px;
+  transform: translateY(-10%);
+}
+
+.page-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  background: linear-gradient(120deg, #c85a1d, #f2b25d, #c46cc7);
+  color: #0f172a;
+  border-radius: 999px;
+  font-weight: 600;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.08);
+}
+
+.toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--panel);
+  color: var(--text);
+  cursor: pointer;
+  box-shadow: var(--shadow);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.toggle:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 14px 40px rgba(0, 0, 0, 0.12);
+}
+
+.toggle-thumb {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #c85a1d, #c46cc7);
+  display: inline-block;
+}
+
+.toggle-text {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.content {
+  margin-top: 48px;
+  display: grid;
+  gap: 32px;
+}
+
+.hero {
+  display: grid;
+  gap: 18px;
+  justify-items: center;
+  text-align: center;
+}
+
+.logo-mark {
+  width: 260px;
+  height: 260px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  background-size: 200% 200%;
+  box-shadow: 0 25px 80px rgba(0, 0, 0, 0.15);
+  animation: drift 12s ease-in-out infinite;
+}
+
+.logo-glyph {
+  background: #0b0b0b;
+  color: #f5f5f5;
+  width: 88%;
+  height: 88%;
+  border-radius: 40px;
+  display: grid;
+  place-items: center;
+  font-size: 64px;
+  font-weight: 700;
+  letter-spacing: -0.04em;
+  text-transform: lowercase;
+  box-shadow: inset 0 2px 0 rgba(255, 255, 255, 0.1),
+    inset 0 -4px 14px rgba(0, 0, 0, 0.35);
+}
+
+.tagline {
+  max-width: 720px;
+  font-size: 1.1rem;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.panel {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 28px;
+  padding: 28px;
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(10px);
+}
+
+.panel-header,
+.list-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.panel-title {
+  margin: 4px 0 0;
+  font-size: 1.4rem;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-size: 0.75rem;
+  color: var(--muted);
+  margin: 0;
+}
+
+.status-chip {
+  padding: 8px 12px;
+  border-radius: 14px;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.18);
+  color: var(--text);
+  font-weight: 600;
+}
+
+.form {
+  display: grid;
+  gap: 18px;
+  margin-top: 20px;
+}
+
+.field {
+  display: grid;
+  gap: 8px;
+}
+
+.field-label {
+  font-weight: 600;
+  color: var(--muted);
+}
+
+.field input {
+  width: 100%;
+  padding: 14px 16px;
+  border-radius: 14px;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text);
+  font-size: 1rem;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+.field input:focus {
+  outline: none;
+  border-color: #0a84ff;
+  box-shadow: 0 10px 30px rgba(10, 132, 255, 0.15);
+}
+
+.alias-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.base-host {
+  padding: 12px 14px;
+  background: rgba(15, 23, 42, 0.06);
+  border-radius: 12px;
+  color: var(--muted);
+  border: 1px solid var(--border);
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.primary {
+  border: none;
+  padding: 14px 20px;
+  border-radius: 14px;
+  background: linear-gradient(120deg, #c85a1d, #f2b25d, #c46cc7);
+  color: #0b0b0b;
+  font-weight: 700;
+  cursor: pointer;
+  box-shadow: 0 15px 40px rgba(0, 0, 0, 0.16);
+  transition: transform 0.15s ease, box-shadow 0.2s ease;
+}
+
+.primary:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.18);
+}
+
+.hint {
+  color: var(--muted);
+}
+
+.feedback {
+  margin-top: 12px;
+  padding: 12px 14px;
+  border-radius: 12px;
+  background: rgba(52, 199, 89, 0.12);
+  color: #188247;
+  border: 1px solid rgba(52, 199, 89, 0.3);
+  font-weight: 600;
+}
+
+.badge-row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.swatch {
+  width: 22px;
+  height: 22px;
+  border-radius: 8px;
+  border: 1px solid rgba(0, 0, 0, 0.05);
+}
+
+.link-list {
+  list-style: none;
+  padding: 0;
+  margin: 16px 0 0;
+  display: grid;
+  gap: 12px;
+}
+
+.link-row {
+  padding: 16px;
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.04);
   display: flex;
   justify-content: space-between;
+  gap: 16px;
   align-items: center;
-  padding: 10px;
+  flex-wrap: wrap;
 }
 
-.header span {
-  font-size: 1.2rem;
+.link-alias {
+  margin: 0;
+  font-weight: 700;
 }
 
-.daysOfWeek, .days {
-  display: grid;
-  grid-template-columns: repeat(7, 1fr);
+.link-destination {
+  margin: 6px 0 0;
+  color: var(--muted);
+  max-width: 580px;
+  word-break: break-word;
 }
 
-.dayOfWeek, .day {
-  padding: 10px 0;
-  margin-bottom: 20px;
+.link-meta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
 }
 
-.empty {
-  visibility: hidden;
+.meta-chip {
+  padding: 8px 12px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  color: var(--muted);
 }
 
-.icon-style {
-  color: white;
-  font-size: 1.5rem;
+.ghost {
+  border: 1px solid var(--border);
+  background: transparent;
+  padding: 10px 14px;
+  border-radius: 12px;
+  color: var(--text);
+  cursor: pointer;
+  transition: border 0.2s ease, transform 0.15s ease;
 }
 
-.month {
-  position: absolute;
-  padding-bottom: 10%;
-  left:35%
+.ghost:hover {
+  border-color: #0a84ff;
+  transform: translateY(-1px);
 }
 
-.current-day {
-  height: 70%;
-  border-radius: 10px;
-  background-color: rgba(77, 66, 66, 0.5);
-  border: 2px inset #000000;
-  box-shadow: inset 2px 2px 5px rgb(0, 0, 0), inset -2px -2px 5px rgba(58, 43, 43, 0.1);
+.empty-state {
+  border: 1px dashed var(--border);
+  padding: 18px;
+  border-radius: 14px;
+  color: var(--muted);
+}
+
+@keyframes drift {
+  0% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0% 50%;
+  }
+}
+
+@media (max-width: 640px) {
+  .page-shell {
+    padding: 32px 18px 56px;
+  }
+
+  .logo-mark {
+    width: 200px;
+    height: 200px;
+  }
+
+  .panel {
+    padding: 22px;
+  }
+
+  .link-row {
+    flex-direction: column;
+    align-items: flex-start;
+  }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,12 +1,14 @@
 import './globals.css';
 import { Inter } from 'next/font/google';
+import React from 'react';
 
 const inter = Inter({ subsets: ['latin'] });
 
 export const metadata = {
-  title: 'My Health Portal',
-  description: 'Fitness, Nutrition & Sleep',
+  title: 'clkly | Effortless Link Shortening',
+  description: 'A modern, server-inspired landing for clkly link shortening.',
 };
+
 export default function RootLayout({
   children,
 }: {
@@ -14,7 +16,6 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body className={inter.className}>{children}</body>
       <head>
         <meta property="og:image" content="/icon.jpg" />
         <link
@@ -39,6 +40,7 @@ export default function RootLayout({
         />
         <link rel="manifest" href="/site.webmanifest" />
       </head>
+      <body className={inter.className}>{children}</body>
     </html>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,7 +4,7 @@ import React, { FormEvent, useEffect, useMemo, useState } from 'react';
 import posthog from 'posthog-js';
 
 const rainbow = ['#c85a1d', '#f2b25d', '#c46cc7'];
-const baseHost = 'https://clk.ly';
+const baseHost = process.env.NEXT_PUBLIC_SHORT_LINK_BASE_URL || 'https://clk.ly';
 let posthogInitialized = false;
 
 function initPosthog() {
@@ -34,11 +34,30 @@ type ShortLink = {
   createdAt: string;
 };
 
+type ApiLink = {
+  alias: string;
+  destinationUrl: string;
+  shortUrl: string;
+  createdAt: string;
+};
+
+function toShortLink(link: ApiLink): ShortLink {
+  return {
+    id: `${link.alias}-${link.createdAt}`,
+    alias: link.alias,
+    originalUrl: link.destinationUrl,
+    shortUrl: link.shortUrl,
+    createdAt: link.createdAt,
+  };
+}
+
 export default function HomePage() {
   const [theme, setTheme] = useState<'light' | 'dark'>('light');
   const [destination, setDestination] = useState('');
   const [customAlias, setCustomAlias] = useState('');
   const [shortLinks, setShortLinks] = useState<ShortLink[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const [feedback, setFeedback] = useState<string | null>(null);
 
   useEffect(() => {
@@ -67,6 +86,42 @@ export default function HomePage() {
     }
   }, [theme]);
 
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      setIsLoading(true);
+      try {
+        const response = await fetch('/api/links');
+        if (!response.ok) {
+          throw new Error('Unable to load your links right now.');
+        }
+
+        const data = (await response.json()) as { links?: ApiLink[] };
+        const parsed = (data.links || []).map(toShortLink);
+        if (!cancelled) {
+          setShortLinks(parsed);
+          capture('links_loaded', { count: parsed.length });
+        }
+      } catch (error) {
+        if (!cancelled) {
+          setFeedback('Unable to load your existing links. Please try again.');
+          capture('links_load_failed', { reason: error instanceof Error ? error.message : 'unknown' });
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   const accentGradient = useMemo(
     () =>
       `linear-gradient(120deg, ${rainbow
@@ -75,7 +130,7 @@ export default function HomePage() {
     [],
   );
 
-  const handleShorten = (event: FormEvent<HTMLFormElement>) => {
+  const handleShorten = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     const sanitizedUrl = destination.trim();
     if (!sanitizedUrl) {
@@ -83,27 +138,42 @@ export default function HomePage() {
       return;
     }
 
-    const alias = customAlias.trim() || `clk-${Math.random().toString(36).slice(2, 8)}`;
-    const now = new Date().toISOString();
-    const shortUrl = `${baseHost}/${alias}`;
+    setIsSubmitting(true);
+    setFeedback(null);
 
-    const newLink: ShortLink = {
-      id: crypto.randomUUID(),
-      originalUrl: sanitizedUrl,
-      alias,
-      shortUrl,
-      createdAt: now,
-    };
+    try {
+      const response = await fetch('/api/links', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ destination: sanitizedUrl, alias: customAlias.trim() || undefined }),
+      });
 
-    setShortLinks((prev) => [newLink, ...prev]);
-    setFeedback('Fresh short link generated. Ship it when you are ready.');
-    capture('link_shortened', {
-      alias,
-      hasCustomAlias: Boolean(customAlias.trim()),
-      destinationLength: sanitizedUrl.length,
-    });
-    setCustomAlias('');
-    setDestination('');
+      const data = (await response.json()) as { link?: ApiLink; message?: string };
+
+      if (!response.ok || !data.link) {
+        const message = data.message || 'Unable to create your short link right now.';
+        setFeedback(message);
+        capture('link_create_failed', { message, status: response.status });
+        return;
+      }
+
+      const newLink = toShortLink(data.link);
+      setShortLinks((prev) => [newLink, ...prev]);
+      setFeedback('Fresh short link generated and synced to Sheets.');
+      capture('link_shortened', {
+        alias: newLink.alias,
+        hasCustomAlias: Boolean(customAlias.trim()),
+        destinationLength: sanitizedUrl.length,
+      });
+      setCustomAlias('');
+      setDestination('');
+    } catch (error) {
+      const message = 'Unable to create your short link right now.';
+      setFeedback(message);
+      capture('link_create_failed', { reason: error instanceof Error ? error.message : 'unknown' });
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
   const toggleTheme = () => setTheme((prev) => (prev === 'light' ? 'dark' : 'light'));
@@ -141,7 +211,7 @@ export default function HomePage() {
               <p className="eyebrow">Shorten anything</p>
               <h2 className="panel-title">Drop a link. Choose your endpoint. Ship.</h2>
             </div>
-            <div className="status-chip">No database required yet</div>
+            <div className="status-chip">Private Google Sheet backend</div>
           </div>
 
           <form className="form" onSubmit={handleShorten}>
@@ -173,8 +243,8 @@ export default function HomePage() {
             </label>
 
             <div className="actions">
-              <button type="submit" className="primary">
-                Shorten link
+              <button type="submit" className="primary" disabled={isSubmitting}>
+                {isSubmitting ? 'Saving to Sheets…' : 'Shorten link'}
               </button>
               <p className="hint">All server-ready. Swap in Sheets later for persistence and auditability.</p>
             </div>
@@ -195,7 +265,12 @@ export default function HomePage() {
           </div>
 
           <ul className="link-list">
-            {shortLinks.length === 0 && (
+            {isLoading && (
+              <li className="empty-state">
+                <p>Loading your links from the private sheet…</p>
+              </li>
+            )}
+            {!isLoading && shortLinks.length === 0 && (
               <li className="empty-state">
                 <p>
                   Nothing shortened yet. Paste a link above and watch clkly shape it into a crisp endpoint.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,234 @@
-import Home from '../pages/home';
+'use client';
 
-export default Home;
+import React, { FormEvent, useEffect, useMemo, useState } from 'react';
+import posthog from 'posthog-js';
+
+const rainbow = ['#c85a1d', '#f2b25d', '#c46cc7'];
+const baseHost = 'https://clk.ly';
+let posthogInitialized = false;
+
+function initPosthog() {
+  const key = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+  if (typeof window === 'undefined' || !key || posthogInitialized) {
+    return;
+  }
+
+  posthog.init(key, {
+    api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST || 'https://app.posthog.com',
+    autocapture: false,
+    capture_pageview: false,
+  });
+  posthogInitialized = true;
+}
+
+function capture(event: string, properties: Record<string, unknown>) {
+  if (!posthogInitialized) return;
+  posthog.capture(event, properties);
+}
+
+type ShortLink = {
+  id: string;
+  originalUrl: string;
+  alias: string;
+  shortUrl: string;
+  createdAt: string;
+};
+
+export default function HomePage() {
+  const [theme, setTheme] = useState<'light' | 'dark'>('light');
+  const [destination, setDestination] = useState('');
+  const [customAlias, setCustomAlias] = useState('');
+  const [shortLinks, setShortLinks] = useState<ShortLink[]>([]);
+  const [feedback, setFeedback] = useState<string | null>(null);
+
+  useEffect(() => {
+    initPosthog();
+  }, []);
+
+  useEffect(() => {
+    const storedTheme =
+      typeof window !== 'undefined' ? localStorage.getItem('clkly-theme') : null;
+    if (storedTheme === 'light' || storedTheme === 'dark') {
+      setTheme(storedTheme);
+      return;
+    }
+
+    const prefersDark =
+      typeof window !== 'undefined' &&
+      window.matchMedia('(prefers-color-scheme: dark)').matches;
+    setTheme(prefersDark ? 'dark' : 'light');
+  }, []);
+
+  useEffect(() => {
+    if (typeof document !== 'undefined') {
+      document.body.dataset.theme = theme;
+      localStorage.setItem('clkly-theme', theme);
+      capture('theme_toggled', { theme });
+    }
+  }, [theme]);
+
+  const accentGradient = useMemo(
+    () =>
+      `linear-gradient(120deg, ${rainbow
+        .map((shade, index) => `${shade} ${(index / rainbow.length) * 100}%`)
+        .join(', ')})`,
+    [],
+  );
+
+  const handleShorten = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const sanitizedUrl = destination.trim();
+    if (!sanitizedUrl) {
+      setFeedback('Please drop in a destination URL to shorten.');
+      return;
+    }
+
+    const alias = customAlias.trim() || `clk-${Math.random().toString(36).slice(2, 8)}`;
+    const now = new Date().toISOString();
+    const shortUrl = `${baseHost}/${alias}`;
+
+    const newLink: ShortLink = {
+      id: crypto.randomUUID(),
+      originalUrl: sanitizedUrl,
+      alias,
+      shortUrl,
+      createdAt: now,
+    };
+
+    setShortLinks((prev) => [newLink, ...prev]);
+    setFeedback('Fresh short link generated. Ship it when you are ready.');
+    capture('link_shortened', {
+      alias,
+      hasCustomAlias: Boolean(customAlias.trim()),
+      destinationLength: sanitizedUrl.length,
+    });
+    setCustomAlias('');
+    setDestination('');
+  };
+
+  const toggleTheme = () => setTheme((prev) => (prev === 'light' ? 'dark' : 'light'));
+
+  return (
+    <div className="page-shell">
+      <div className="grid-backdrop" aria-hidden>
+        {rainbow.map((shade, index) => (
+          <span key={shade} className="grid-stripe" style={{ background: shade, opacity: 0.04 * (index + 1) }} />
+        ))}
+      </div>
+
+      <header className="page-header">
+        <div className="pill">Server-side energy, zero bloat</div>
+        <button className="toggle" onClick={toggleTheme} aria-label="Toggle color mode">
+          <span className="toggle-thumb" />
+          <span className="toggle-text">{theme === 'light' ? 'Light' : 'Dark'} mode</span>
+        </button>
+      </header>
+
+      <main className="content">
+        <section className="hero">
+          <div className="logo-mark" style={{ backgroundImage: accentGradient }}>
+            <div className="logo-glyph">clkly</div>
+          </div>
+          <p className="tagline">
+            A minimal, Apple-inspired command center for shortening links. Keep it lean, keep it fast, and plug in Sheets when
+            you are ready to persist.
+          </p>
+        </section>
+
+        <section className="panel">
+          <div className="panel-header">
+            <div>
+              <p className="eyebrow">Shorten anything</p>
+              <h2 className="panel-title">Drop a link. Choose your endpoint. Ship.</h2>
+            </div>
+            <div className="status-chip">No database required yet</div>
+          </div>
+
+          <form className="form" onSubmit={handleShorten}>
+            <label className="field">
+              <span className="field-label">Destination URL</span>
+              <input
+                type="url"
+                name="destination"
+                placeholder="https://design.apple.com/inspiration"
+                value={destination}
+                onChange={(event) => setDestination(event.target.value)}
+                required
+              />
+            </label>
+
+            <label className="field">
+              <span className="field-label">Custom endpoint (optional)</span>
+              <div className="alias-row">
+                <span className="base-host">{baseHost}/</span>
+                <input
+                  type="text"
+                  name="alias"
+                  placeholder="colorstream"
+                  value={customAlias}
+                  onChange={(event) => setCustomAlias(event.target.value.replace(/\s+/g, '-'))}
+                  maxLength={32}
+                />
+              </div>
+            </label>
+
+            <div className="actions">
+              <button type="submit" className="primary">
+                Shorten link
+              </button>
+              <p className="hint">All server-ready. Swap in Sheets later for persistence and auditability.</p>
+            </div>
+          </form>
+
+          {feedback && <p className="feedback">{feedback}</p>}
+
+          <div className="list-header">
+            <div>
+              <p className="eyebrow">Shortened links</p>
+              <h3 className="panel-title">Your freshly minted endpoints</h3>
+            </div>
+            <div className="badge-row">
+              {rainbow.map((tone) => (
+                <span key={tone} className="swatch" style={{ background: tone }} />
+              ))}
+            </div>
+          </div>
+
+          <ul className="link-list">
+            {shortLinks.length === 0 && (
+              <li className="empty-state">
+                <p>
+                  Nothing shortened yet. Paste a link above and watch clkly shape it into a crisp endpoint.
+                </p>
+              </li>
+            )}
+            {shortLinks.map((link) => (
+              <li key={link.id} className="link-row">
+                <div>
+                  <p className="link-alias">{link.shortUrl}</p>
+                  <p className="link-destination" title={link.originalUrl}>
+                    {link.originalUrl}
+                  </p>
+                </div>
+                <div className="link-meta">
+                  <span className="meta-chip">{new Date(link.createdAt).toLocaleString()}</span>
+                  <button
+                    type="button"
+                    className="ghost"
+                    onClick={() => {
+                      navigator.clipboard.writeText(link.shortUrl);
+                      setFeedback('Copied to clipboard. Ready for launch.');
+                      capture('link_copied', { alias: link.alias });
+                    }}
+                  >
+                    Copy
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/src/lib/sheets.ts
+++ b/src/lib/sheets.ts
@@ -1,0 +1,140 @@
+import { google } from 'googleapis';
+
+export type LinkRow = {
+  alias: string;
+  destinationUrl: string;
+  shortUrl: string;
+  createdAt: string;
+};
+
+type ServiceAccountConfig = {
+  client_email: string;
+  private_key: string;
+};
+
+const SCOPES = ['https://www.googleapis.com/auth/spreadsheets'];
+const DEFAULT_SHEET_NAME = 'Links';
+const SHEET_HEADERS = ['Alias', 'Destination URL', 'Short URL', 'Created At'];
+
+function decodeServiceAccountKey(key: string): ServiceAccountConfig {
+  const trimmed = key.trim();
+  try {
+    return JSON.parse(trimmed) as ServiceAccountConfig;
+  } catch (error) {
+    const decoded = Buffer.from(trimmed, 'base64').toString('utf-8');
+    return JSON.parse(decoded) as ServiceAccountConfig;
+  }
+}
+
+function resolveServiceAccount(): ServiceAccountConfig {
+  const inlineJson = process.env.GOOGLE_SERVICE_ACCOUNT_KEY;
+  if (inlineJson) {
+    return decodeServiceAccountKey(inlineJson);
+  }
+
+  const client_email = process.env.GOOGLE_SERVICE_ACCOUNT_EMAIL;
+  const privateKey = process.env.GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY;
+  if (client_email && privateKey) {
+    return {
+      client_email,
+      private_key: privateKey.replace(/\\n/g, '\n'),
+    };
+  }
+
+  throw new Error('Google service account credentials are not configured.');
+}
+
+function getSheetsClient() {
+  const credentials = resolveServiceAccount();
+  const auth = new google.auth.GoogleAuth({
+    credentials,
+    scopes: SCOPES,
+  });
+
+  return google.sheets({ version: 'v4', auth });
+}
+
+function spreadsheetIdFromEnv(): string {
+  const documentId = process.env.GOOGLE_SHEETS_DOCUMENT_ID;
+  if (!documentId) {
+    throw new Error('GOOGLE_SHEETS_DOCUMENT_ID is required to access Sheets.');
+  }
+  return documentId;
+}
+
+async function ensureHeaderRow(sheetsApi: ReturnType<typeof getSheetsClient>, spreadsheetId: string, sheetName: string) {
+  const current = await sheetsApi.spreadsheets.values.get({
+    spreadsheetId,
+    range: `${sheetName}!A1:D1`,
+  });
+
+  const existingHeaders = current.data.values?.[0];
+  if (existingHeaders && existingHeaders.length >= SHEET_HEADERS.length) {
+    return;
+  }
+
+  await sheetsApi.spreadsheets.values.update({
+    spreadsheetId,
+    range: `${sheetName}!A1:D1`,
+    valueInputOption: 'RAW',
+    requestBody: {
+      values: [SHEET_HEADERS],
+    },
+  });
+}
+
+function mapRow(row: string[]): LinkRow | null {
+  if (row.length < 4) return null;
+
+  const [alias, destinationUrl, shortUrl, createdAt] = row;
+  if (!alias || !destinationUrl || !shortUrl || !createdAt) return null;
+
+  return {
+    alias,
+    destinationUrl,
+    shortUrl,
+    createdAt,
+  };
+}
+
+export async function fetchLinksFromSheet(sheetName = DEFAULT_SHEET_NAME): Promise<LinkRow[]> {
+  const sheetsApi = getSheetsClient();
+  const spreadsheetId = spreadsheetIdFromEnv();
+
+  await ensureHeaderRow(sheetsApi, spreadsheetId, sheetName);
+
+  const response = await sheetsApi.spreadsheets.values.get({
+    spreadsheetId,
+    range: `${sheetName}!A2:D`,
+  });
+
+  const rows = response.data.values ?? [];
+  const records = rows
+    .map(mapRow)
+    .filter((row): row is LinkRow => Boolean(row))
+    .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+
+  return records;
+}
+
+export async function appendLinkRow(
+  link: LinkRow,
+  sheetName = DEFAULT_SHEET_NAME,
+): Promise<LinkRow> {
+  const sheetsApi = getSheetsClient();
+  const spreadsheetId = spreadsheetIdFromEnv();
+
+  await ensureHeaderRow(sheetsApi, spreadsheetId, sheetName);
+
+  await sheetsApi.spreadsheets.values.append({
+    spreadsheetId,
+    range: `${sheetName}!A:D`,
+    valueInputOption: 'RAW',
+    insertDataOption: 'INSERT_ROWS',
+    requestBody: {
+      values: [[link.alias, link.destinationUrl, link.shortUrl, link.createdAt]],
+    },
+  });
+
+  return link;
+}


### PR DESCRIPTION
## Summary
- rebuild the landing page into a modern clkly-themed link shortener surface
- add light/dark theming, 80s apple-inspired visuals, and inline link list UX with a 3-color burnt-orange-centric gradient treatment
- introduce PostHog instrumentation hooks for theme toggles and link actions

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927ef0106c88325a0ed8a954694c0d3)