### PR TITLE
Default optional daily trackers off

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@chakra-ui/react": "^2.8.1",
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
+        "@fortawesome/fontawesome-svg-core": "^6.7.2",
         "@fortawesome/free-solid-svg-icons": "^6.5.2",
         "@fortawesome/react-fontawesome": "^0.2.2",
         "@types/node": "20.3.1",
@@ -3793,7 +3794,6 @@
       "version": "6.7.2",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.7.2.tgz",
       "integrity": "sha512-yxtOBWDrdi5DD5o1pmVdq3WMCvnobT0LU6R8RyyVXPvFRd2o79/0NCuQoCjNTeZz9EzA9xS3JxNWfv54RIHFEA==",
-      "peer": true,
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "6.7.2"
       },

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@chakra-ui/react": "^2.8.1",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
+    "@fortawesome/fontawesome-svg-core": "^6.7.2",
     "@fortawesome/free-solid-svg-icons": "^6.5.2",
     "@fortawesome/react-fontawesome": "^0.2.2",
     "@types/node": "20.3.1",

--- a/src/__tests__/landing.test.tsx
+++ b/src/__tests__/landing.test.tsx
@@ -12,48 +12,60 @@ const renderLanding = () =>
 describe('Landing', () => {
   beforeEach(() => localStorage.clear());
 
-  it('shows the main action buttons on the home screen', () => {
+  it('shows sleep as the only default daily quick action on the home screen', () => {
     renderLanding();
-    expect(screen.getByRole('button', { name: /gym/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /eat/i })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /gym/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /eat/i }),
+    ).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: /sleep/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /calendar/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /calendar/i }),
+    ).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /config/i })).toBeInTheDocument();
   });
 
   it('hides the optional trackers until enabled in config', () => {
     renderLanding();
-    expect(screen.queryByRole('button', { name: /sober/i })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /sober/i }),
+    ).not.toBeInTheDocument();
     expect(
       screen.queryByRole('button', { name: /symptoms/i }),
     ).not.toBeInTheDocument();
   });
 
-  it('removes the gym/food buttons when their daily trackers are disabled', () => {
+  it('shows the gym/food buttons when their daily trackers are enabled', () => {
     localStorage.setItem(
       'trackerConfig',
       JSON.stringify({
         daily: {
           sleep: { enabled: true, label: 'Sleep', icon: 'moon' },
-          workout: { enabled: false, label: 'Workout', icon: 'dumbbell' },
-          food: { enabled: false, label: 'Eating', icon: 'utensils' },
+          workout: { enabled: true, label: 'Workout', icon: 'dumbbell' },
+          food: { enabled: true, label: 'Eating', icon: 'utensils' },
         },
       }),
     );
     renderLanding();
-    expect(screen.queryByRole('button', { name: /gym/i })).not.toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /eat/i })).not.toBeInTheDocument();
-    // Sleep stays — it's the calculator, always available.
+    expect(screen.getByRole('button', { name: /gym/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /eat/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /sleep/i })).toBeInTheDocument();
   });
 
   it('shows the sober/symptoms buttons when enabled in config', () => {
     localStorage.setItem(
       'trackerConfig',
-      JSON.stringify({ sobriety: { enabled: true }, symptoms: { enabled: true } }),
+      JSON.stringify({
+        sobriety: { enabled: true },
+        symptoms: { enabled: true },
+      }),
     );
     renderLanding();
     expect(screen.getByRole('button', { name: /sober/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /symptoms/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /symptoms/i }),
+    ).toBeInTheDocument();
   });
 });

--- a/src/__tests__/tracker-storage.test.ts
+++ b/src/__tests__/tracker-storage.test.ts
@@ -35,14 +35,20 @@ describe('tracker config', () => {
   });
 
   it('persists and reloads config', () => {
-    saveTrackerConfig({ ...DEFAULT_TRACKER_CONFIG, symptoms: { enabled: true } });
+    saveTrackerConfig({
+      ...DEFAULT_TRACKER_CONFIG,
+      symptoms: { enabled: true },
+    });
     expect(getTrackerConfig().symptoms.enabled).toBe(true);
   });
 
   it('merges newly-added defaults into older stored config', () => {
     localStorage.setItem(
       'trackerConfig',
-      JSON.stringify({ daily: DEFAULT_TRACKER_CONFIG.daily, sobriety: { enabled: true } }),
+      JSON.stringify({
+        daily: DEFAULT_TRACKER_CONFIG.daily,
+        sobriety: { enabled: true },
+      }),
     );
     const config = getTrackerConfig();
     expect(config.sobriety.enabled).toBe(true);
@@ -54,6 +60,7 @@ describe('tracker config', () => {
       ...DEFAULT_TRACKER_CONFIG,
       daily: {
         ...DEFAULT_TRACKER_CONFIG.daily,
+        workout: { enabled: true, label: 'Workout', icon: 'dumbbell' as const },
         food: { enabled: false, label: 'Eating', icon: 'utensils' as const },
       },
     };
@@ -108,12 +115,16 @@ describe('sobriety', () => {
 
   it('counts whole days since the start date', () => {
     const now = new Date(2026, 0, 11);
-    expect(daysSober({ id: 's', label: 'x', startDate: '2026-01-01' }, now)).toBe(10);
+    expect(
+      daysSober({ id: 's', label: 'x', startDate: '2026-01-01' }, now),
+    ).toBe(10);
   });
 
   it('never returns a negative count for a future start date', () => {
     const now = new Date(2026, 0, 1);
-    expect(daysSober({ id: 's', label: 'x', startDate: '2026-06-01' }, now)).toBe(0);
+    expect(
+      daysSober({ id: 's', label: 'x', startDate: '2026-06-01' }, now),
+    ).toBe(0);
   });
 
   it('returns 0 for a malformed start date', () => {
@@ -144,7 +155,10 @@ describe('clearTrackerData', () => {
   });
 
   it('clears everything on "all" but keeps config', () => {
-    saveTrackerConfig({ ...DEFAULT_TRACKER_CONFIG, symptoms: { enabled: true } });
+    saveTrackerConfig({
+      ...DEFAULT_TRACKER_CONFIG,
+      symptoms: { enabled: true },
+    });
     setRating('2026-06-12', 'sleep', 4);
     saveCycles([{ start: '2026-06-01' }]);
     setSymptomSeverity('2026-06-12', 'front:chest', 3);
@@ -168,7 +182,10 @@ describe('legacy sleep migration', () => {
   it('does not overwrite an existing day-log sleep entry', () => {
     jest.resetModules();
     localStorage.setItem('sleep', JSON.stringify({ '2025-01-10': 3 }));
-    localStorage.setItem('dayLog', JSON.stringify({ '2025-01-10': { sleep: 5 } }));
+    localStorage.setItem(
+      'dayLog',
+      JSON.stringify({ '2025-01-10': { sleep: 5 } }),
+    );
     const mod = require('@/utils/tracker-storage');
     mod.migrateLegacySleep();
     expect(mod.getRating('2025-01-10', 'sleep')).toBe(5);

--- a/src/types/trackers.ts
+++ b/src/types/trackers.ts
@@ -27,7 +27,11 @@ export interface TrackerConfig {
 }
 
 /** The four menstrual-cycle phases, each independently shown/hidden. */
-export type CyclePhaseName = 'menstrual' | 'follicular' | 'ovulation' | 'luteal';
+export type CyclePhaseName =
+  | 'menstrual'
+  | 'follicular'
+  | 'ovulation'
+  | 'luteal';
 export type CyclePhaseToggles = Record<CyclePhaseName, boolean>;
 
 /** A logged menstrual cycle: when the period started and (optionally) ended. */
@@ -58,8 +62,8 @@ export type SymptomLog = Record<string, Record<string, number>>;
 export const DEFAULT_TRACKER_CONFIG: TrackerConfig = {
   daily: {
     sleep: { enabled: true, label: 'Sleep', icon: 'moon' },
-    workout: { enabled: true, label: 'Workout', icon: 'dumbbell' },
-    food: { enabled: true, label: 'Eating', icon: 'utensils' },
+    workout: { enabled: false, label: 'Workout', icon: 'dumbbell' },
+    food: { enabled: false, label: 'Eating', icon: 'utensils' },
   },
   sobriety: { enabled: false },
   symptoms: { enabled: false },


### PR DESCRIPTION
### Motivation
- Make the home screen show only the Sleep quick-action by default so gym (workout) and food (eating) are opt-in via settings, reducing initial UI clutter.
- Update tests and storage logic to reflect the new default behavior and ensure opt-in toggles still work.

### Description
- Set `workout` and `food` default toggles to `enabled: false` in `DEFAULT_TRACKER_CONFIG` (file: `src/types/trackers.ts`).
- Updated landing tests to assert sleep is the only default quick-action and that gym/eat buttons appear when their toggles are enabled (file: `src/__tests__/landing.test.tsx`).
- Updated tracker-storage tests to explicitly enable `workout` in the test that expects it to be reported as enabled under the new defaults (file: `src/__tests__/tracker-storage.test.ts`).
- Applied Prettier formatting to the modified files.

### Testing
- Ran formatting with `npx prettier --write` on the changed files (succeeded); note the repository does not provide an `npm run format` script so `prettier` was invoked directly.
- Ran the test suite with `npm test -- --runInBand`, and all tests passed (`4` test suites, `44` tests).
- Built the app with `npm run build`, which completed successfully.

No PostHog events were added because this change only updates static defaults and tests; there was no clear analytics hook to capture for this config-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5ed52d07388325adf256e62adf8688)