### PR TITLE
Add daily medication tracking

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "start": "next start",
     "lint": "next lint",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build"
+    "build-storybook": "storybook build",
+    "format": "prettier --write \"src/{app,components,contexts,types,utils,views,__tests__}/**/*.{ts,tsx,css}\" package.json"
   },
   "dependencies": {
     "@chakra-ui/icons": "^2.1.1",

--- a/src/__tests__/landing.test.tsx
+++ b/src/__tests__/landing.test.tsx
@@ -35,6 +35,9 @@ describe('Landing', () => {
     expect(
       screen.queryByRole('button', { name: /symptoms/i }),
     ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /medications/i }),
+    ).not.toBeInTheDocument();
   });
 
   it('shows the gym/food buttons when their daily trackers are enabled', () => {
@@ -60,12 +63,16 @@ describe('Landing', () => {
       JSON.stringify({
         sobriety: { enabled: true },
         symptoms: { enabled: true },
+        medications: { enabled: true },
       }),
     );
     renderLanding();
     expect(screen.getByRole('button', { name: /sober/i })).toBeInTheDocument();
     expect(
       screen.getByRole('button', { name: /symptoms/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /medications/i }),
     ).toBeInTheDocument();
   });
 });

--- a/src/__tests__/tracker-storage.test.ts
+++ b/src/__tests__/tracker-storage.test.ts
@@ -13,7 +13,11 @@ import {
   setSymptomSeverity,
   clearTrackerData,
   getCycles,
+  getMedicationLogForDate,
+  getPrescriptions,
   saveCycles,
+  savePrescriptions,
+  setMedicationTaken,
   toDateKey,
 } from '@/utils/tracker-storage';
 import { DEFAULT_TRACKER_CONFIG } from '@/types/trackers';
@@ -189,5 +193,26 @@ describe('legacy sleep migration', () => {
     const mod = require('@/utils/tracker-storage');
     mod.migrateLegacySleep();
     expect(mod.getRating('2025-01-10', 'sleep')).toBe(5);
+  });
+});
+
+describe('medication tracking', () => {
+  it('persists prescriptions', () => {
+    const prescriptions = [{ id: 'm1', label: 'Vitamin D' }];
+    savePrescriptions(prescriptions);
+    expect(getPrescriptions()).toEqual(prescriptions);
+  });
+
+  it('tracks taken medication per day and resets naturally on a new date', () => {
+    savePrescriptions([{ id: 'm1', label: 'Vitamin D' }]);
+    setMedicationTaken('2026-07-21', 'm1', true);
+    expect(getMedicationLogForDate('2026-07-21')).toEqual({ m1: true });
+    expect(getMedicationLogForDate('2026-07-22')).toEqual({});
+  });
+
+  it('removes a medication check-in when untoggled', () => {
+    setMedicationTaken('2026-07-21', 'm1', true);
+    setMedicationTaken('2026-07-21', 'm1', false);
+    expect(getMedicationLogForDate('2026-07-21')).toEqual({});
   });
 });

--- a/src/__tests__/views.test.tsx
+++ b/src/__tests__/views.test.tsx
@@ -1,10 +1,13 @@
 import { render, screen, fireEvent, within } from '@testing-library/react';
 import BodyMap from '@/views/symptoms/body-map';
 import Sober from '@/views/sober/sober';
+import Medications from '@/views/medications';
 import DayEditor from '@/views/calendar/day-editor';
 import {
   getSymptomsForDate,
+  getMedicationLogForDate,
   getRating,
+  savePrescriptions,
   saveSobrietyStreaks,
   toDateKey,
 } from '@/utils/tracker-storage';
@@ -43,6 +46,19 @@ describe('Sober', () => {
   });
 });
 
+describe('Medications', () => {
+  it('checks off a configured prescription for today', () => {
+    const today = toDateKey(new Date());
+    savePrescriptions([{ id: 'm1', label: 'Vitamin D' }]);
+    render(<Medications />);
+    fireEvent.click(
+      screen.getByRole('button', { name: /vitamin d not taken/i }),
+    );
+    expect(getMedicationLogForDate(today)).toEqual({ m1: true });
+    expect(screen.getByText(/1 of 1 taken today/i)).toBeInTheDocument();
+  });
+});
+
 describe('DayEditor', () => {
   it('persists a 1-5 rating per tracker (no text inputs)', () => {
     const date = toDateKey(new Date());
@@ -69,8 +85,14 @@ describe('DayEditor', () => {
     );
     const date = toDateKey(new Date());
     render(<DayEditor date={date} onClose={() => {}} />);
-    expect(screen.getByRole('radiogroup', { name: /sleep/i })).toBeInTheDocument();
-    expect(screen.getByRole('radiogroup', { name: /workout/i })).toBeInTheDocument();
-    expect(screen.getByRole('radiogroup', { name: /eating/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole('radiogroup', { name: /sleep/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('radiogroup', { name: /workout/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('radiogroup', { name: /eating/i }),
+    ).toBeInTheDocument();
   });
 });

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -500,6 +500,7 @@ select {
 .day-editor,
 .config-view,
 .sober-view,
+.medications-view,
 .body-map {
   background: #0b0b0b;
   color: white;
@@ -519,6 +520,7 @@ select {
 /* Config / sober / body map are rendered as centered panels on the page. */
 .config-view,
 .sober-view,
+.medications-view,
 .body-map {
   margin: 8vh auto 0;
 }
@@ -919,6 +921,64 @@ select {
 }
 .sober-milestone svg {
   margin-right: 0.3rem;
+}
+
+
+/* Medication checklist. */
+.med-progress {
+  margin-bottom: 0.8rem;
+  color: rgba(248, 158, 157, 0.95);
+  font-weight: 700;
+  text-align: center;
+}
+.med-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+}
+.med-card {
+  width: 100%;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 0.75rem;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 12px;
+  color: white;
+  cursor: pointer;
+  font-family: inherit;
+  padding: 0.85rem;
+  text-align: left;
+  transition: background 0.15s ease, border-color 0.15s ease, transform 0.12s ease;
+}
+.med-card:active {
+  transform: scale(0.98);
+}
+.med-card.taken {
+  background: rgba(94, 201, 139, 0.16);
+  border-color: rgba(94, 201, 139, 0.55);
+}
+.med-icon {
+  width: 2rem;
+  height: 2rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: rgba(212, 111, 147, 0.2);
+  color: #f9a8d4;
+}
+.med-card.taken .med-icon {
+  background: rgba(94, 201, 139, 0.25);
+  color: #9ff0bf;
+}
+.med-name {
+  font-weight: 700;
+}
+.med-status {
+  color: rgba(255, 255, 255, 0.62);
+  font-size: 0.8rem;
 }
 
 /* Body map. */

--- a/src/types/trackers.ts
+++ b/src/types/trackers.ts
@@ -20,6 +20,8 @@ export interface TrackerConfig {
   daily: Record<DailyTrackerKey, DailyTrackerConfig>;
   /** Show the sobriety day-counter button on the main page. */
   sobriety: { enabled: boolean };
+  /** Show the medication checklist button on the main page. */
+  medications: { enabled: boolean };
   /** Show the body-map symptom diary button on the main page. */
   symptoms: { enabled: boolean };
   /** Enable menstrual-cycle logging + predictions on the calendar. */
@@ -53,6 +55,18 @@ export interface SobrietyStreak {
   startDate: string; // "YYYY-MM-DD"
 }
 
+/** A prescription the user wants reminded to take once per day. */
+export interface Prescription {
+  id: string;
+  label: string;
+}
+
+/** A day's medication checklist, keyed by prescription id. */
+export type MedicationLogEntry = Record<string, boolean>;
+
+/** Map of "YYYY-MM-DD" -> medication checklist for that day. */
+export type MedicationLog = Record<string, MedicationLogEntry>;
+
 /** Body-map views. Region keys are stored as "<view>:<region>" e.g. "front:chest". */
 export type BodyView = 'front' | 'back';
 
@@ -66,6 +80,7 @@ export const DEFAULT_TRACKER_CONFIG: TrackerConfig = {
     food: { enabled: false, label: 'Eating', icon: 'utensils' },
   },
   sobriety: { enabled: false },
+  medications: { enabled: false },
   symptoms: { enabled: false },
   cycle: {
     enabled: false,

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -1,0 +1,18 @@
+type PostHogLike = {
+  capture?: (eventName: string, properties?: Record<string, unknown>) => void;
+};
+
+declare global {
+  interface Window {
+    posthog?: PostHogLike;
+  }
+}
+
+/** Best-effort PostHog capture without requiring PostHog to be installed. */
+export const captureEvent = (
+  eventName: string,
+  properties?: Record<string, unknown>,
+): void => {
+  if (typeof window === 'undefined') return;
+  window.posthog?.capture?.(eventName, properties);
+};

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -3,7 +3,15 @@ import CryptoJS from 'crypto-js';
 // Frontend-only "backup/restore": the user's tracker data is bundled, encrypted,
 // and copied to / pasted from the clipboard. No backend involved.
 const SECRET_KEY = 'mySecretKey';
-const TRACKER_KEYS = ['trackerConfig', 'dayLog', 'sobriety', 'symptoms', 'cycles'];
+const TRACKER_KEYS = [
+  'trackerConfig',
+  'dayLog',
+  'sobriety',
+  'prescriptions',
+  'medicationLog',
+  'symptoms',
+  'cycles',
+];
 
 /** Encrypt all tracker data into the clipboard as a single portable string. */
 export const encryptLocalStorage = async (): Promise<void> => {

--- a/src/utils/tracker-storage.ts
+++ b/src/utils/tracker-storage.ts
@@ -5,6 +5,9 @@ import {
   type CycleRecord,
   type DayEntry,
   type DayLog,
+  type MedicationLog,
+  type MedicationLogEntry,
+  type Prescription,
   type SobrietyStreak,
   type SymptomLog,
   type TrackerConfig,
@@ -13,6 +16,8 @@ import {
 const CONFIG_KEY = 'trackerConfig';
 const DAY_LOG_KEY = 'dayLog';
 const SOBRIETY_KEY = 'sobriety';
+const PRESCRIPTIONS_KEY = 'prescriptions';
+const MEDICATION_LOG_KEY = 'medicationLog';
 const SYMPTOMS_KEY = 'symptoms';
 const CYCLE_KEY = 'cycles';
 const LEGACY_SLEEP_KEY = 'sleep';
@@ -63,8 +68,18 @@ export const getTrackerConfig = (): TrackerConfig => {
   if (!stored) return DEFAULT_TRACKER_CONFIG;
   return {
     daily: { ...DEFAULT_TRACKER_CONFIG.daily, ...(stored.daily ?? {}) },
-    sobriety: { ...DEFAULT_TRACKER_CONFIG.sobriety, ...(stored.sobriety ?? {}) },
-    symptoms: { ...DEFAULT_TRACKER_CONFIG.symptoms, ...(stored.symptoms ?? {}) },
+    sobriety: {
+      ...DEFAULT_TRACKER_CONFIG.sobriety,
+      ...(stored.sobriety ?? {}),
+    },
+    medications: {
+      ...DEFAULT_TRACKER_CONFIG.medications,
+      ...(stored.medications ?? {}),
+    },
+    symptoms: {
+      ...DEFAULT_TRACKER_CONFIG.symptoms,
+      ...(stored.symptoms ?? {}),
+    },
     cycle: {
       ...DEFAULT_TRACKER_CONFIG.cycle,
       ...(stored.cycle ?? {}),
@@ -179,6 +194,52 @@ export const daysSober = (
 };
 
 // ---------------------------------------------------------------------------
+// Medication tracking
+// ---------------------------------------------------------------------------
+
+export const getPrescriptions = (): Prescription[] =>
+  read<Prescription[]>(PRESCRIPTIONS_KEY, []).filter(
+    (prescription) => prescription.id && prescription.label,
+  );
+
+export const savePrescriptions = (prescriptions: Prescription[]): void => {
+  write(PRESCRIPTIONS_KEY, prescriptions);
+};
+
+export const getMedicationLog = (): MedicationLog => {
+  const raw = read<Record<string, Record<string, unknown>>>(
+    MEDICATION_LOG_KEY,
+    {},
+  );
+  const log: MedicationLog = {};
+  for (const [date, entry] of Object.entries(raw)) {
+    const day: MedicationLogEntry = {};
+    for (const [prescriptionId, taken] of Object.entries(entry ?? {})) {
+      if (taken === true) day[prescriptionId] = true;
+    }
+    if (Object.keys(day).length) log[date] = day;
+  }
+  return log;
+};
+
+export const getMedicationLogForDate = (date: string): MedicationLogEntry =>
+  getMedicationLog()[date] ?? {};
+
+export const setMedicationTaken = (
+  date: string,
+  prescriptionId: string,
+  taken: boolean,
+): void => {
+  const log = getMedicationLog();
+  const day = { ...(log[date] ?? {}) };
+  if (taken) day[prescriptionId] = true;
+  else delete day[prescriptionId];
+  if (Object.keys(day).length) log[date] = day;
+  else delete log[date];
+  write(MEDICATION_LOG_KEY, log);
+};
+
+// ---------------------------------------------------------------------------
 // Symptom diary (body map) — 1-5 severity per region per day
 // ---------------------------------------------------------------------------
 
@@ -229,11 +290,18 @@ export const saveCycles = (cycles: CycleRecord[]): void => {
 // Reset / clear data (per section, or everything)
 // ---------------------------------------------------------------------------
 
-export type ResetSection = 'daily' | 'sobriety' | 'symptoms' | 'cycles' | 'all';
+export type ResetSection =
+  | 'daily'
+  | 'sobriety'
+  | 'medications'
+  | 'symptoms'
+  | 'cycles'
+  | 'all';
 
 const SECTION_KEYS: Record<Exclude<ResetSection, 'all'>, string> = {
   daily: DAY_LOG_KEY,
   sobriety: SOBRIETY_KEY,
+  medications: MEDICATION_LOG_KEY,
   symptoms: SYMPTOMS_KEY,
   cycles: CYCLE_KEY,
 };
@@ -242,9 +310,15 @@ const SECTION_KEYS: Record<Exclude<ResetSection, 'all'>, string> = {
 export const clearTrackerData = (section: ResetSection): void => {
   if (!hasWindow()) return;
   if (section === 'all') {
-    [DAY_LOG_KEY, SOBRIETY_KEY, SYMPTOMS_KEY, CYCLE_KEY, LEGACY_SLEEP_KEY].forEach(
-      (k) => localStorage.removeItem(k),
-    );
+    [
+      DAY_LOG_KEY,
+      SOBRIETY_KEY,
+      PRESCRIPTIONS_KEY,
+      MEDICATION_LOG_KEY,
+      SYMPTOMS_KEY,
+      CYCLE_KEY,
+      LEGACY_SLEEP_KEY,
+    ].forEach((k) => localStorage.removeItem(k));
   } else {
     localStorage.removeItem(SECTION_KEYS[section]);
   }

--- a/src/views/config/config.tsx
+++ b/src/views/config/config.tsx
@@ -5,8 +5,10 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faPlus, faTrash } from '@fortawesome/free-solid-svg-icons';
 import {
   clearTrackerData,
+  getPrescriptions,
   getSobrietyStreaks,
   getTrackerConfig,
+  savePrescriptions,
   saveSobrietyStreaks,
   saveTrackerConfig,
   toDateKey,
@@ -14,7 +16,11 @@ import {
 } from '../../utils/tracker-storage';
 import { encryptLocalStorage, decryptLocalStorage } from '../../utils/session';
 import { trackerIcon } from '../../utils/tracker-icons';
-import type { SobrietyStreak, TrackerConfig } from '../../types/trackers';
+import type {
+  Prescription,
+  SobrietyStreak,
+  TrackerConfig,
+} from '../../types/trackers';
 
 interface ConfigProps {
   /** Notified whenever config or streaks change, so the main page can refresh. */
@@ -41,6 +47,7 @@ const Toggle: React.FC<{
 const Config: React.FC<ConfigProps> = ({ onChanged }) => {
   const [config, setConfig] = useState<TrackerConfig | null>(null);
   const [streaks, setStreaks] = useState<SobrietyStreak[]>([]);
+  const [prescriptions, setPrescriptions] = useState<Prescription[]>([]);
   const [exported, setExported] = useState(false);
   const [importValue, setImportValue] = useState('');
   const [importError, setImportError] = useState(false);
@@ -48,6 +55,7 @@ const Config: React.FC<ConfigProps> = ({ onChanged }) => {
   useEffect(() => {
     setConfig(getTrackerConfig());
     setStreaks(getSobrietyStreaks());
+    setPrescriptions(getPrescriptions());
   }, []);
 
   const handleExport = async () => {
@@ -70,6 +78,7 @@ const Config: React.FC<ConfigProps> = ({ onChanged }) => {
     if (!window.confirm(`Reset ${label}? This can’t be undone.`)) return;
     clearTrackerData(section);
     setStreaks(getSobrietyStreaks());
+    setPrescriptions(getPrescriptions());
     onChanged?.();
   };
 
@@ -87,7 +96,10 @@ const Config: React.FC<ConfigProps> = ({ onChanged }) => {
     onChanged?.();
   };
 
-  const updateDaily = (key: string, patch: Partial<{ enabled: boolean; label: string }>) => {
+  const updateDaily = (
+    key: string,
+    patch: Partial<{ enabled: boolean; label: string }>,
+  ) => {
     persistConfig({
       ...config,
       daily: { ...config.daily, [key]: { ...config.daily[key], ...patch } },
@@ -111,6 +123,27 @@ const Config: React.FC<ConfigProps> = ({ onChanged }) => {
   const removeStreak = (id: string) =>
     persistStreaks(streaks.filter((s) => s.id !== id));
 
+  const persistPrescriptions = (next: Prescription[]) => {
+    setPrescriptions(next);
+    savePrescriptions(next);
+    onChanged?.();
+  };
+
+  const addPrescription = () => {
+    persistPrescriptions([
+      ...prescriptions,
+      { id: `m_${Date.now()}`, label: 'Medication name' },
+    ]);
+  };
+
+  const updatePrescription = (id: string, patch: Partial<Prescription>) =>
+    persistPrescriptions(
+      prescriptions.map((p) => (p.id === id ? { ...p, ...patch } : p)),
+    );
+
+  const removePrescription = (id: string) =>
+    persistPrescriptions(prescriptions.filter((p) => p.id !== id));
+
   return (
     <div className="config-view">
       <h2 className="overlay-title">Configure trackers</h2>
@@ -122,7 +155,10 @@ const Config: React.FC<ConfigProps> = ({ onChanged }) => {
           const cfg = config.daily[key];
           return (
             <div key={key} className="config-row">
-              <FontAwesomeIcon icon={trackerIcon(cfg.icon)} className="config-row-icon" />
+              <FontAwesomeIcon
+                icon={trackerIcon(cfg.icon)}
+                className="config-row-icon"
+              />
               <input
                 className="config-input"
                 value={cfg.label}
@@ -152,6 +188,16 @@ const Config: React.FC<ConfigProps> = ({ onChanged }) => {
           />
         </div>
         <div className="config-row">
+          <span className="config-row-label">Medication tracking</span>
+          <Toggle
+            checked={config.medications.enabled}
+            onChange={(enabled) =>
+              persistConfig({ ...config, medications: { enabled } })
+            }
+            label="Enable medication tracking"
+          />
+        </div>
+        <div className="config-row">
           <span className="config-row-label">Symptom diary (body map)</span>
           <Toggle
             checked={config.symptoms.enabled}
@@ -176,7 +222,9 @@ const Config: React.FC<ConfigProps> = ({ onChanged }) => {
       {config.cycle.enabled && (
         <section className="config-section">
           <h3>Cycle phases</h3>
-          <p className="config-hint">Which phases to outline on the calendar.</p>
+          <p className="config-hint">
+            Which phases to outline on the calendar.
+          </p>
           {(
             [
               ['menstrual', 'Menstrual'],
@@ -206,6 +254,42 @@ const Config: React.FC<ConfigProps> = ({ onChanged }) => {
         </section>
       )}
 
+      {config.medications.enabled && (
+        <section className="config-section">
+          <h3>Prescriptions</h3>
+          <p className="config-hint">
+            Add each medication you want to check off once per day.
+          </p>
+          {prescriptions.map((prescription) => (
+            <div key={prescription.id} className="config-row">
+              <input
+                className="config-input"
+                value={prescription.label}
+                onChange={(e) =>
+                  updatePrescription(prescription.id, { label: e.target.value })
+                }
+                aria-label="Prescription label"
+              />
+              <button
+                type="button"
+                className="icon-button"
+                onClick={() => removePrescription(prescription.id)}
+                aria-label="Remove prescription"
+              >
+                <FontAwesomeIcon icon={faTrash} />
+              </button>
+            </div>
+          ))}
+          <button
+            type="button"
+            className="link-button"
+            onClick={addPrescription}
+          >
+            <FontAwesomeIcon icon={faPlus} /> Add prescription
+          </button>
+        </section>
+      )}
+
       {config.sobriety.enabled && (
         <section className="config-section">
           <h3>Sobriety streaks</h3>
@@ -214,7 +298,9 @@ const Config: React.FC<ConfigProps> = ({ onChanged }) => {
               <input
                 className="config-input"
                 value={streak.label}
-                onChange={(e) => updateStreak(streak.id, { label: e.target.value })}
+                onChange={(e) =>
+                  updateStreak(streak.id, { label: e.target.value })
+                }
                 aria-label="Streak label"
               />
               <input
@@ -292,6 +378,13 @@ const Config: React.FC<ConfigProps> = ({ onChanged }) => {
             onClick={() => resetSection('sobriety', 'sobriety streaks')}
           >
             Reset sobriety
+          </button>
+          <button
+            type="button"
+            className="reset-btn"
+            onClick={() => resetSection('medications', 'medication check-ins')}
+          >
+            Reset medication check-ins
           </button>
           <button
             type="button"

--- a/src/views/landing.tsx
+++ b/src/views/landing.tsx
@@ -9,6 +9,7 @@ import {
   faGear,
   faMoon,
   faPerson,
+  faPills,
   faUtensils,
   faWineBottle,
 } from '@fortawesome/free-solid-svg-icons';
@@ -24,6 +25,7 @@ import DayEditor from './calendar/day-editor';
 import Config from './config/config';
 import Sober from './sober/sober';
 import BodyMap from './symptoms/body-map';
+import Medications from './medications';
 
 type View =
   | 'gym'
@@ -32,7 +34,8 @@ type View =
   | 'calendar'
   | 'config'
   | 'sober'
-  | 'symptoms';
+  | 'symptoms'
+  | 'medications';
 
 export default function Landing() {
   const { setText } = useContext(FadingTextContext);
@@ -88,6 +91,7 @@ export default function Landing() {
       )}
       {view === 'sober' && <Sober />}
       {view === 'symptoms' && <BodyMap date={bodyMapDate} />}
+      {view === 'medications' && <Medications />}
 
       {view === null && (
         <div className="button-container">
@@ -125,10 +129,19 @@ export default function Landing() {
               <FontAwesomeIcon icon={faWineBottle} size="lg" color="white" />
             </button>
           )}
+          {config?.medications.enabled && (
+            <button
+              aria-label="medications"
+              className="circle-button button5"
+              onClick={() => setView('medications')}
+            >
+              <FontAwesomeIcon icon={faPills} size="lg" color="white" />
+            </button>
+          )}
           {config?.symptoms.enabled && (
             <button
               aria-label="symptoms"
-              className="circle-button button5"
+              className="circle-button button6"
               onClick={() => openBodyMap(undefined)}
             >
               <FontAwesomeIcon icon={faPerson} size="lg" color="white" />

--- a/src/views/medications.tsx
+++ b/src/views/medications.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faCheck, faPills } from '@fortawesome/free-solid-svg-icons';
+import { captureEvent } from '../utils/analytics';
+import {
+  getMedicationLogForDate,
+  getPrescriptions,
+  setMedicationTaken,
+  toDateKey,
+} from '../utils/tracker-storage';
+import type { MedicationLogEntry, Prescription } from '../types/trackers';
+
+const Medications: React.FC = () => {
+  const [today, setToday] = useState('');
+  const [prescriptions, setPrescriptions] = useState<Prescription[]>([]);
+  const [takenById, setTakenById] = useState<MedicationLogEntry>({});
+
+  const reload = (date = toDateKey(new Date())) => {
+    setToday(date);
+    setPrescriptions(getPrescriptions());
+    setTakenById(getMedicationLogForDate(date));
+  };
+
+  useEffect(() => {
+    reload();
+  }, []);
+
+  const toggleTaken = (prescription: Prescription) => {
+    const taken = !takenById[prescription.id];
+    setMedicationTaken(today, prescription.id, taken);
+    setTakenById((current) => ({ ...current, [prescription.id]: taken }));
+    captureEvent('medication_taken_toggled', {
+      prescription_id: prescription.id,
+      date: today,
+      taken,
+    });
+  };
+
+  const completed = prescriptions.filter((p) => takenById[p.id]).length;
+
+  return (
+    <div className="medications-view">
+      <h2 className="overlay-title">Today&apos;s medication</h2>
+      {prescriptions.length === 0 ? (
+        <p className="overlay-empty">
+          No prescriptions yet. Add one in config to start tracking daily doses.
+        </p>
+      ) : (
+        <>
+          <p className="config-hint">
+            Resets each day. Mark each prescription once you&apos;ve taken it.
+          </p>
+          <div className="med-progress" aria-live="polite">
+            {completed} of {prescriptions.length} taken today
+          </div>
+          <div className="med-list">
+            {prescriptions.map((prescription) => {
+              const taken = Boolean(takenById[prescription.id]);
+              return (
+                <button
+                  key={prescription.id}
+                  type="button"
+                  className={`med-card ${taken ? 'taken' : ''}`}
+                  onClick={() => toggleTaken(prescription)}
+                  aria-pressed={taken}
+                  aria-label={`${prescription.label} ${taken ? 'taken' : 'not taken'}`}
+                >
+                  <span className="med-icon">
+                    <FontAwesomeIcon icon={taken ? faCheck : faPills} />
+                  </span>
+                  <span className="med-name">{prescription.label}</span>
+                  <span className="med-status">
+                    {taken ? 'Taken' : 'Not yet'}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default Medications;


### PR DESCRIPTION
### Motivation

- Add a simple per-prescription daily checklist so users can mark medications as taken and have the state reset each day. 
- Expose a settings UI to configure prescriptions (add/edit/remove) similar to sobriety streaks and make the feature toggleable. 
- Capture a PostHog event for medication check-ins to enable product analytics while keeping the integration optional.

### Description

- Added types for prescriptions and medication logs and a default `medications.enabled` flag in `src/types/trackers.ts`.
- Implemented localStorage-backed persistence and helpers in `src/utils/tracker-storage.ts` to store prescriptions and per-day boolean check-ins keyed by `YYYY-MM-DD`, plus read/write helpers and reset support; medication data is included in backup/restore and clear flows (`src/utils/session.ts`, `tracker-storage.ts`).
- Exposed a new settings section in the existing config UI to toggle medication tracking and add/edit/remove prescriptions, and added a reset action for medication check-ins (`src/views/config/config.tsx`).
- Added a new overlay view `Medications` (`src/views/medications.tsx`) reachable from the home screen when enabled, with per-prescription toggle buttons and a small progress summary; added styling to `src/app/globals.css` and a lightweight best-effort analytics helper `src/utils/analytics.ts` to fire `medication_taken_toggled` events.
- Added unit tests for storage and UI behavior (updates to `src/__tests__/tracker-storage.test.ts`, `src/__tests__/views.test.tsx`, `src/__tests__/landing.test.tsx`) and ensured code formatting via a `format` script in `package.json`.

### Testing

- Ran `npm run format` to format changed files; formatting completed successfully.
- Ran `npm test -- --runInBand` and all test suites passed (4 test suites, 48 tests total).
- Ran `npm run build` (`next build`) and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5f009b36388325ade472508c279e91)